### PR TITLE
fix file path now case sensitive match

### DIFF
--- a/server/src/tests/resolver.spec.ts
+++ b/server/src/tests/resolver.spec.ts
@@ -192,7 +192,7 @@ describe('Reolver tracking', () => {
 
   const symbolKindPath = join(
     __dirname,
-    '../../../kerboscripts/parser_valid/unitTests/scannerTest.ks',
+    '../../../kerboscripts/parser_valid/unitTests/scannertest.ks',
   );
 
   // test basic identifier


### PR DESCRIPTION
- azure pipelines couldn't find scannertest.ks because it builds in a case
sensitive environment where windows is case insensitive and passes
