### PR TITLE
Return and Break Updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,5 @@
   "typescript.tsc.autoDetect": "off",
   "npm.exclude": ["**/clients", "**/server"],
   "npm.enableScriptExplorer": true,
+  "breadcrumbs.enabled": true,
 }

--- a/clients/vscode/grammars/kos.tmLanguage.json
+++ b/clients/vscode/grammars/kos.tmLanguage.json
@@ -1,1142 +1,1231 @@
 {
-    "version": "",
-    "name": "Kerbal Operating System",
-    "scopeName": "source.kos",
-    "patterns": [{
-        "include": "#statements"
-    }],
-    "repository": {
-        "statements": {
-            "patterns": [{
-                    "include": "#string"
-                },
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#control-statement"
-                },
-                {
-                    "include": "#directive"
-                },
-                {
-                    "include": "#declaration"
-                }
-            ]
-        },
-        "directive": {
-            "patterns": [{
-                "match": "(?i)(\\@)(lazyglobal)\\s+\\b(on|off)\\s*\\.",
-                "captures": {
-                    "1": {
-                        "name": "keyword.operator.directive.kos"
-                    },
-                    "2": {
-                        "name": "keyword.directive.lazyGlobal.kos"
-                    },
-                    "3": {
-                        "name": "keyword.control.lazyGlobal.kos"
-                    },
-                    "4": {
-                        "name": "punctuation.terminator.statement.kos"
-                    }
-                }
-            }]
-        },
-        "declaration": {
-            "patterns": [{
-                    "include": "#function-declaration"
-                },
-                {
-                    "include": "#parameter-declaration"
-                },
-                {
-                    "include": "#lock-declaration"
-                },
-                {
-                    "include": "#variable-declaration"
-                },
-                {
-                    "include": "#instruction"
-                }
-            ]
-        },
-        "function-declaration": {
-            "name": "meta.function.kos",
-            "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?\\b(function)\\s+([_[:alpha:]][_[:alnum:]]*)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.declaration.declare.kos"
-                },
-                "2": {
-                    "name": "storage.modifier.scope.kos"
-                },
-                "3": {
-                    "name": "storage.type.function.kos"
-                },
-                "4": {
-                    "name": "meta.definition.function.kos entity.name.function.kos"
-                }
-            },
-            "end": "(?<=\\})",
-            "patterns": [{
-                "include": "#block"
-            }]
-        },
-        "parameter-declaration": {
-            "name": "meta.declaration.parameter",
-            "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?\\b(parameter)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.declaration.declare.kos"
-                },
-                "2": {
-                    "name": "storage.modifier.scope.kos"
-                },
-                "3": {
-                    "name": "storage.type.parameter.kos"
-                }
-            },
-            "end": "\\.",
-            "patterns": [
-                {
-                    "include": "#comment"
-                },
-                {
-                    "include": "#punctuation-comma"
-                },
-                {
-                    "include": "#parameter-body"
-                }
-            ]
-        },
-        "parameter-body": {
-            "begin": "(?i)\\b([_[:alpha:]][_[:alnum:]]*)(?:\\s+\\b(is|to)\\s+)?\\s*",
-            "beginCaptures": {
-                "1": {
-                    "name": "variable.parameter.kos"
-                },
-                "2": {
-                    "name": "keyword.assignment.assign.kos"
-                }
-            },
-            "end": "(?=(\\,|\\.))",
-            "patterns": [
-                {
-                    "include": "#comment"
-                },    
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "lock-declaration": {
-            "name": "meta.declaration.lock",
-            "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?(\\block)\\s+\\b([_[:alpha:]][_[:alnum:]]*)\\s+(\\bto)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.declaration.declare.kos"
-                },
-                "2": {
-                    "name": "storage.modifier.scope.kos"
-                },
-                "3": {
-                    "name": "storage.type.lock.kos"
-                },
-                "4": {
-                    "name": "variable.other.kos"
-                },
-                "5": {
-                    "name": "keyword.assignment.assign.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "variable-declaration": {
-            "patterns": [{
-                    "include": "#variable-declaration-declare"
-                },
-                {
-                    "include": "#variable-declaration-scope"
-                }
-            ]
-        },
-        "variable-declaration-declare": {
-            "name": "meta.declaration.variable",
-            "begin": "(?i)\\b(declare)\\s+(?:\\b(local|global)\\s+)?\\b([_[:alpha:]][_[:alnum:]]*)\\s+\\b(is|to)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.declaration.declare.kos"
-                },
-                "2": {
-                    "name": "storage.modifier.scope.kos"
-                },
-                "3": {
-                    "name": "variable.other.kos"
-                },
-                "4": {
-                    "name": "keyword.assignment.assign.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "variable-declaration-scope": {
-            "name": "meta.declaration.variable",
-            "begin": "(?i)\\b(local|global)\\s+\\b([_[:alpha:]][_[:alnum:]]*)\\s+\\b(to|is)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "storage.modifier.scope.kos"
-                },
-                "2": {
-                    "name": "variable.other.kos"
-                },
-                "3": {
-                    "name": "keyword.assignment.assign.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "block": {
-            "name": "meta.block.kos",
-            "begin": "\\{",
-            "beginCaptures": {
-                "0": {
-                    "name": "punctuation.definition.block.kos"
-                }
-            },
-            "end": "\\}",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.definition.block.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#statements"
-            }]
-        },
-        "control-statement": {
-            "patterns": [{
-                    "name": "keyword.control.conditional.kos",
-                    "match": "(?i)(?<![_[:alnum:]\\:])(else|if)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.control.trigger.kos",
-                    "match": "(?i)(?<![_[:alnum:]\\:])(when|then|on)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "match": "(?i)\\b(preserve)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.control.trigger.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                },
-                {
-                    "match": "(?i)\\b(stage)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.control.stage.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                },
-                {
-                    "name": "keyword.control.flow.kos",
-                    "match": "(?i)(?<![_[:alnum:]\\:])(until)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.control.loop.kos",
-                    "match": "(?i)(?<![_[:alnum:]\\:])(for|in|from|step|do)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "match": "(?i)\\b(break)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.control.loop.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                },
-                {
-                    "include": "#return-statement"
-                },
-                {
-                    "include": "#toggle-statement"
-                },
-                {
-                    "include": "#wait-statement"
-                }
-            ]
-        },
-        "return-statement": {
-            "begin": "(?i)(?<![_[:alnum:]\\:])(return)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.control.flow.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "toggle-statement": {
-            "begin": "(?<![_[:alnum:]\\:])(?i)(toggle)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.control.toggle.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#suffix"
-            }]
-        },
-        "wait-statement": {
-            "begin": "(?i)(?<![_[:alnum:]\\:])(wait)\\s+(\\b(until)\\s)?",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.control.wait.kos"
-                },
-                "2": {
-                    "name": "keyword.control.until.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "instruction": {
-            "patterns": [{
-                    "include": "#set-instruction"
-                },
-                {
-                    "include": "#unassign-instruction"
-                },
-                {
-                    "include": "#print-instruction"
-                },
-                {
-                    "include": "#copy-instruction"
-                },
-                {
-                    "include": "#rename-instruction"
-                },
-                {
-                    "include": "#switch-instruction"
-                },
-                {
-                    "include": "#delete-instruction"
-                },
-                {
-                    "include": "#compile-instruction"
-                },
-                {
-                    "include": "#log-instruction"
-                },
-                {
-                    "include": "#run-instruction"
-                },
-                {
-                    "include": "#run-path-instruction"
-                },
-                {
-                    "include": "#run-path-once-instruction"
-                },
-                {
-                    "include": "#list-instruction"
-                },
-                {
-                    "include": "#command-instructions"
-                },
-                {
-                    "include": "#node-instructions"
-                },
-                {
-                    "include": "#block"
-                },
-                {
-                    "include": "#expression"
-                },
-                {
-                    "include": "#punctuation-period"
-                }
-            ]
-        },
-        "set-instruction": {
-            "begin": "(?i)\\b(set)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.assignment.set.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#to-operator"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "unassign-instruction": {
-            "name": "meta.unassignment.kos",
-            "begin": "(?i)\\b(unset|unlock)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.assignment.unassign.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "name": "keyword.other.unassign.all.kos",
-                    "matches": "(?i)\\ball"
-                },
-                {
-                    "includes": "#identifier"
-                }
-            ]
-        },
-        "print-instruction": {
-            "name": "meta.print.kos",
-            "begin": "(?i)\\b(print)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.print.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#print-at-expression"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "print-at-expression": {
-            "begin": "(?i)\\b(at)\\s*\\(",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.at.kos"
-                }
-            },
-            "end": "\\)",
-            "patterns": [{
-                    "include": "#punctuation-comma"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "copy-instruction": {
-            "name": "meta.copy.kos",
-            "begin": "(?i)\\b(copy)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.copy.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#to-from-operators"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "rename-instruction": {
-            "name": "meta.rename.kos",
-            "begin": "(?i)\\b(rename)\\s+\\b(file|volume)\\s+",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.rename.kos"
-                },
-                "2": {
-                    "name": "keyword.other.fileVolume.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#expression"
-                },
-                {
-                    "include": "#to-operator"
-                }
-            ]
-        },
-        "switch-instruction": {
-            "name": "meta.switch.kos",
-            "begin": "(?i)\\b(switch)\\s+\\b(to)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.switch.kos"
-                },
-                "2": {
-                    "name": "keyword.command.switchTo.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "log-instruction": {
-            "begin": "(?i)\\b(log)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.log.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#to-operator"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "delete-instruction": {
-            "name": "meta.delete.kos",
-            "begin": "(?i)\\b(delete)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.delete.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "from-operator"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "compile-instruction": {
-            "name": "meta.compile.kos",
-            "begin": "(?i)\\b(compile)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.compile.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#to-operator"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "run-instruction": {
-            "name": "meta.run.kos",
-            "begin": "(?i)\\b(run)\\s+(?:\\b(once)\\s+)?",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.run.kos"
-                },
-                "2": {
-                    "name": "keyword.command.once.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#call"
-                },
-                {
-                    "include": "#run-on-instruction"
-                },
-                {
-                    "include": "#string"
-                },
-                {
-                    "include": "#file-identiifer"
-                }
-            ]
-        },
-        "run-on-instruction": {
-            "begin": "(?i)\\b(on)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.on.kos"
-                }
-            },
-            "end": "(?=(\\,|\\.))",
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "run-path-instruction": {
-            "name": "meta.runpath.kos",
-            "begin": "(?i)\\b(runpath)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.runpath.kos"
-                }
-            },
-            "end": "\\.",
-            "endCapture": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#call"
-            }]
-        },
-        "run-once-path-instruction": {
-            "name": "meta.runoncepath.kos",
-            "begin": "(?i)\\b(runoncepath)",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.runpath.kos"
-                }
-            },
-            "end": "\\.",
-            "endCapture": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#call"
-            }]
-        },
-        "list-instruction": {
-            "name": "meta.list.kos",
-            "match": "(?i)\\b(list)(?:\\s+\\b([_[:alpha:]][_[:alnum:]]*))?(?:\\s+\\b(in)\\s+\\b([_[:alpha:]][_[:alnum:]]*))?(\\.)",
-            "captures": {
-                "1": {
-                    "name": "keyword.command.list.kos"
-                },
-                "2": {
-                    "name": "variable.other.kos"
-                },
-                "3": {
-                    "name": "keyword.command.in.kos"
-                },
-                "4": {
-                    "name": "variable.other.kos"
-                },
-                "5": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            }
-        },
-        "command-instructions": {
-            "patterns": [{
-                    "match": "(?i)\\b(clearscreen)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.command.clearscreen.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                },
-                {
-                    "match": "(?i)\\b(reboot)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.command.reboot.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                },
-                {
-                    "match": "(?i)\\b(shutdown)(\\.)",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.command.shutdown.kos"
-                        },
-                        "2": {
-                            "name": "punctuation.terminator.statement.kos"
-                        }
-                    }
-                }
-            ]
-        },
-        "node-instructions": {
-            "patterns": [
-                {
-                    "include": "#node-add"
-                },
-                {
-                    "include": "#node-remove"
-                },
-                {
-                    "include": "#node-edit"
-                }
-            ]
-        },
-        "node-add": {
-            "name": "meta.node.add.kos",
-            "begin": "(?i)\\b(add)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.add.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#expression"
-                }
-            ]
-        },
-        "node-edit": {
-            "name": "meta.node.edit.kos",
-            "begin": "(?i)\\b(edit)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.edit.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#expression"
-                }
-            ]
-        },
-        "node-remove": {
-            "name": "meta.node.remove.kos",
-            "begin": "(?i)\\b(remove)(?![_[:alnum:]\\:])",
-            "beginCaptures": {
-                "1": {
-                    "name": "keyword.command.add.kos"
-                }
-            },
-            "end": "\\.",
-            "endCaptures": {
-                "1": {
-                    "name": "punctuation.terminator.statement.kos"
-                }
-            },
-            "patterns": [{
-                    "include": "#expression"
-                }
-            ]
-        },
-        "expression": {
-            "patterns": [{
-                    "include": "#expressions-without-identifiers"
-                },
-                {
-                    "include": "#suffix"
-                },
-                {
-                    "include": "#white-space"
-                }
-            ]
-        },
-        "expressions-without-identifiers": {
-            "patterns": [{
-                    "include": "#comment"
-                },
-                {
-                    "include": "#string"
-                },
-                {
-                    "include": "#block"
-                },
-                {
-                    "include": "#expression-operators"
-                }
-            ]
-        },
-        "expression-operators": {
-            "patterns": [{
-                    "name": "keyword.operator.expression.or.kos",
-                    "match": "(or)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.expression.and.kos",
-                    "match": "(and)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.expression.not.kos",
-                    "match": "(not)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.expression.defined.kos",
-                    "match": "(defined)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.expression.on.kos",
-                    "match": "(on)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.expression.off.kos",
-                    "match": "(off)(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "keyword.operator.power.kos",
-                    "match": "\\^"
-                },
-                {
-                    "name": "keyword.operator.comparison.kos",
-                    "match": "<>|="
-                },
-                {
-                    "name": "keyword.operator.relational.kos",
-                    "match": "<=|>=|<|>"
-                },
-                {
-                    "name": "keyword.operator.arithmetic.kos",
-                    "match": "\\*|/|-|\\+"
-                }
-            ]
-        },
-        "suffix": {
-            "patterns": [{
-                    "include": "#function-call"
-                },
-                {
-                    "include": "#delegate"
-                },
-                {
-                    "include": "#atom"
-                },
-                {
-                    "include": "#array-index"
-                },
-                {
-                    "include": "#array-brackets"
-                }
-            ]
-        },
-        "array-index": {
-            "match": "(\\#)([0-9]+|([_[:alpha:]][_[:alnum:]]*)(?![_[:alnum:]\\:]))",
-            "captures": {
-                "1": {
-                    "name": "meta.pound.kos"
-                },
-                "2": {
-                    "name": "variable.parameter.kos"
-                }
-            }
-        },
-        "array-brackets": {
-            "begin": "\\[",
-            "beingCaptures": {
-                "1": {
-                    "name": "meta.brace.square.kos"
-                }
-            },
-            "end": "\\]",
-            "endCaptures": {
-                "1": {
-                    "name": "meta.brace.square.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "function-call": {
-            "name": "meta.functioncall.kos",
-            "begin": "(\\:)?([_[:alpha:]][_[:alnum:]]*)\\s*(\\()",
-            "beginCaptures": {
-                "1": {
-                    "name": "punctuation.accessor.block.kos"
-                },
-                "2": {
-                    "name": "entity.name.function.kos"
-                },
-                "3": {
-                    "name": "meta.brace.round.kos"
-                }
-            },
-            "end": "\\)",
-            "endCaptures": {
-                "1": {
-                    "name": "meta.brace.round.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#arguments"
-            }]
-        },
-        "delegate": {
-            "name": "meta.delegate.kos",
-            "match": "(\\:)?([_[:alpha:]][_[:alnum:]]*)\\s*(\\@)",
-            "captures": {
-                "1": {
-                    "name": "punctuation.accessor.block.kos"
-                },
-                "2": {
-                    "name": "entity.name.function.kos"
-                },
-                "3": {
-                    "name": "meta.atSign.kos"
-                }
-            }
-        },
-        "call": {
-            "name": "meta.call.kos",
-            "begin": "\\(",
-            "beginCaptures": {
-                "1": {
-                    "name": "meta.brace.round.kos"
-                }
-            },
-            "end": "\\)",
-            "endCaptures": {
-                "1": {
-                    "name": "meta.brace.round.kos"
-                }
-            },
-            "patterns": [{
-                "include": "#arguments"
-            }]
-        },
-        "arguments": {
-            "patterns": [{
-                    "include": "#punctuation-comma"
-                },
-                {
-                    "include": "#expression"
-                }
-            ]
-        },
-        "atom": {
-            "patterns": [{
-                    "include": "#literal"
-                },
-                {
-                    "include": "#file-identiifer"
-                },
-                {
-                    "include": "#identifier"
-                },
-                {
-                    "include": "#identifier-trailer"
-                },
-                {
-                    "include": "#grouping"
-                }
-            ]
-        },
-        "identifier": {
-            "name": "variable.other.identifier.kos",
-            "match": "\\b([_[:alpha:]][_[:alnum:]]*)"
-        },
-        "identifier-trailer": {
-            "name": "variable.other.trailer.kos",
-            "match": "(\\:)([_[:alpha:]][_[:alnum:]]*)(?=(:|\\s))",
-            "captures": {
-                "1": {
-                    "name": "punctuation.accessor.block.kos"
-                },
-                "2": {
-                    "name": "variable.other.trailer"
-                }
-            }
-        },
-        "file-identifier": {
-            "name": "variable.other.fileIdentifier.kos",
-            "match": "\\b([_[:alpha:]][_[:alnum:]]*(?:\\.[_[:alpha:]][_[:alnum:]]*)+)"
-        },
-        "grouping": {
-            "begin": "\\(",
-            "end": "\\)",
-            "patterns": [{
-                "include": "#expression"
-            }]
-        },
-        "comment": {
-            "name": "comment.line.double-slash.kos",
-            "begin": "(^[ \\t]+)?(//)",
-            "beginCaptures": {
-                "1": {
-                    "name": "punctuation.whitespace.comment.leading.kos"
-                },
-                "2": {
-                    "name": "comment.line.double-slash.kos"
-                }
-            },
-            "contentName": "comment.line.comment.kos",
-            "end": "\\n"
-        },
-        "string": {
-            "name": "string.kos",
-            "begin": "\"",
-            "beginCaptures": {
-                "0": {
-                    "name": "punctuation.definition.string.begin.kos"
-                }
-            },
-            "end": "\"",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.definition.string.end.kos"
-                }
-            }
-        },
-        "literal": {
-            "patterns": [{
-                    "include": "#numeric-literal"
-                },
-                {
-                    "include": "#string"
-                },
-                {
-                    "name": "constant.language.true.kos",
-                    "match": "(?i)\\btrue(?![_[:alnum:]\\:])"
-                },
-                {
-                    "name": "constant.language.false.kos",
-                    "match": "(?i)\\bfalse(?![_[:alnum:]\\:])"
-                }
-            ]
-        },
-        "to-from-operators": {
-            "patterns": [{
-                "name": "keyword.command.direction.kos",
-                "match": "(?i)(?<![_[:alnum:]\\:])(to|from)(?![_[:alnum:]\\:])"
-            }]
-        },
-        "from-operator": {
-            "patterns": [{
-                "name": "keyword.command.from.kos",
-                "match": "(?i)(?<![_[:alnum:]\\:])(from)(?![_[:alnum:]\\:])"
-            }]
-        },
-        "to-operator": {
-            "patterns": [{
-                "name": "keyword.command.to.kos",
-                "match": "(?i)(?<![_[:alnum:]\\:])(to)(?![_[:alnum:]\\:])"
-            }]
-        },
-        "white-space": {
-            "name": "punctuation.separator.whitespace.kos",
-            "match": "\\s"
-        },
-        "numeric-literal": {
-            "name": "constant.numeric.number.kos",
-            "match": "-?(?:0|[1-9](?:[0-9_]*[0-9])?)(?:\\.[0-9](?:[0-9_]*[0-9])?)?(?:[eE][+\\-]?[0-9](?:[0-9_]*[0-9])?)?"
-        },
-        "punctuation-comma": {
-            "name": "punctuation.separator.comma.kos",
-            "match": "\\,"
-        },
-        "punctuation-period": {
-            "name": "punctuation.terminator.statement.kos",
-            "match": "\\."
-        }
+  "version": "",
+  "name": "Kerbal Operating System",
+  "scopeName": "source.kos",
+  "patterns": [
+    {
+      "include": "#statements"
     }
+  ],
+  "repository": {
+    "statements": {
+      "patterns": [
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#control-statement"
+        },
+        {
+          "include": "#directive"
+        },
+        {
+          "include": "#declaration"
+        }
+      ]
+    },
+    "directive": {
+      "patterns": [
+        {
+          "match": "(?i)(\\@)(lazyglobal)\\s+\\b(on|off)\\s*\\.",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.directive.kos"
+            },
+            "2": {
+              "name": "keyword.directive.lazyGlobal.kos"
+            },
+            "3": {
+              "name": "keyword.control.lazyGlobal.kos"
+            },
+            "4": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        }
+      ]
+    },
+    "declaration": {
+      "patterns": [
+        {
+          "include": "#function-declaration"
+        },
+        {
+          "include": "#parameter-declaration"
+        },
+        {
+          "include": "#lock-declaration"
+        },
+        {
+          "include": "#variable-declaration"
+        },
+        {
+          "include": "#instruction"
+        }
+      ]
+    },
+    "function-declaration": {
+      "name": "meta.function.kos",
+      "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?\\b(function)\\s+([_[:alpha:]][_[:alnum:]]*)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.declaration.declare.kos"
+        },
+        "2": {
+          "name": "storage.modifier.scope.kos"
+        },
+        "3": {
+          "name": "storage.type.function.kos"
+        },
+        "4": {
+          "name": "meta.definition.function.kos entity.name.function.kos"
+        }
+      },
+      "end": "(?<=\\})",
+      "patterns": [
+        {
+          "include": "#block"
+        }
+      ]
+    },
+    "parameter-declaration": {
+      "name": "meta.declaration.parameter",
+      "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?\\b(parameter)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.declaration.declare.kos"
+        },
+        "2": {
+          "name": "storage.modifier.scope.kos"
+        },
+        "3": {
+          "name": "storage.type.parameter.kos"
+        }
+      },
+      "end": "\\.",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#punctuation-comma"
+        },
+        {
+          "include": "#parameter-body"
+        }
+      ]
+    },
+    "parameter-body": {
+      "begin": "(?i)\\b([_[:alpha:]][_[:alnum:]]*)(?:\\s+\\b(is|to)\\s+)?\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.parameter.kos"
+        },
+        "2": {
+          "name": "keyword.assignment.assign.kos"
+        }
+      },
+      "end": "(?=(\\,|\\.))",
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "lock-declaration": {
+      "name": "meta.declaration.lock",
+      "begin": "(?i)(?:(\\bdeclare)\\s+)?(?:\\b(local|global)\\s+)?(\\block)\\s+\\b([_[:alpha:]][_[:alnum:]]*)\\s+(\\bto)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.declaration.declare.kos"
+        },
+        "2": {
+          "name": "storage.modifier.scope.kos"
+        },
+        "3": {
+          "name": "storage.type.lock.kos"
+        },
+        "4": {
+          "name": "variable.other.kos"
+        },
+        "5": {
+          "name": "keyword.assignment.assign.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "variable-declaration": {
+      "patterns": [
+        {
+          "include": "#variable-declaration-declare"
+        },
+        {
+          "include": "#variable-declaration-scope"
+        }
+      ]
+    },
+    "variable-declaration-declare": {
+      "name": "meta.declaration.variable",
+      "begin": "(?i)\\b(declare)\\s+(?:\\b(local|global)\\s+)?\\b([_[:alpha:]][_[:alnum:]]*)\\s+\\b(is|to)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.declaration.declare.kos"
+        },
+        "2": {
+          "name": "storage.modifier.scope.kos"
+        },
+        "3": {
+          "name": "variable.other.kos"
+        },
+        "4": {
+          "name": "keyword.assignment.assign.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "variable-declaration-scope": {
+      "name": "meta.declaration.variable",
+      "begin": "(?i)\\b(local|global)\\s+\\b([_[:alpha:]][_[:alnum:]]*)\\s+\\b(to|is)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.scope.kos"
+        },
+        "2": {
+          "name": "variable.other.kos"
+        },
+        "3": {
+          "name": "keyword.assignment.assign.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "block": {
+      "name": "meta.block.kos",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.kos"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.block.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#statements"
+        }
+      ]
+    },
+    "control-statement": {
+      "patterns": [
+        {
+          "name": "keyword.control.conditional.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(else|if)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.control.trigger.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(when|then|on)(?![_[:alnum:]\\:])"
+        },
+        {
+          "match": "(?i)\\b(preserve)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.trigger.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        },
+        {
+          "match": "(?i)\\b(stage)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.stage.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        },
+        {
+          "name": "keyword.control.flow.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(until)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.control.loop.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(for|in|from|step|do)(?![_[:alnum:]\\:])"
+        },
+        {
+          "match": "(?i)\\b(break)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.loop.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        },
+        {
+          "include": "#return-statement"
+        },
+        {
+          "include": "#toggle-statement"
+        },
+        {
+          "include": "#wait-statement"
+        }
+      ]
+    },
+    "return-statement": {
+      "patterns": [
+        {
+            "include": "#return-bare"
+        },
+        {
+          "include": "#return-value"
+        }
+      ]
+    },
+    "return-value": {
+      "begin": "(?i)(?<![_[:alnum:]\\:])(return)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.flow.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "return-bare": {
+      "begin": "(?i)(?<![_[:alnum:]\\:])(return)\\s*(\\.)",
+      "captures": {
+        "1": {
+          "name": "keyword.control.flow.kos"
+        },
+        "2": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      }
+    },
+    "toggle-statement": {
+      "begin": "(?<![_[:alnum:]\\:])(?i)(toggle)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.toggle.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#suffix"
+        }
+      ]
+    },
+    "wait-statement": {
+      "begin": "(?i)(?<![_[:alnum:]\\:])(wait)\\s+(\\b(until)\\s)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.wait.kos"
+        },
+        "2": {
+          "name": "keyword.control.until.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "instruction": {
+      "patterns": [
+        {
+          "include": "#set-instruction"
+        },
+        {
+          "include": "#unassign-instruction"
+        },
+        {
+          "include": "#print-instruction"
+        },
+        {
+          "include": "#copy-instruction"
+        },
+        {
+          "include": "#rename-instruction"
+        },
+        {
+          "include": "#switch-instruction"
+        },
+        {
+          "include": "#delete-instruction"
+        },
+        {
+          "include": "#compile-instruction"
+        },
+        {
+          "include": "#log-instruction"
+        },
+        {
+          "include": "#run-instruction"
+        },
+        {
+          "include": "#run-path-instruction"
+        },
+        {
+          "include": "#run-path-once-instruction"
+        },
+        {
+          "include": "#list-instruction"
+        },
+        {
+          "include": "#command-instructions"
+        },
+        {
+          "include": "#node-instructions"
+        },
+        {
+          "include": "#block"
+        },
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#punctuation-period"
+        }
+      ]
+    },
+    "set-instruction": {
+      "begin": "(?i)\\b(set)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.assignment.set.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#to-operator"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "unassign-instruction": {
+      "name": "meta.unassignment.kos",
+      "begin": "(?i)\\b(unset|unlock)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.assignment.unassign.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "name": "keyword.other.unassign.all.kos",
+          "matches": "(?i)\\ball"
+        },
+        {
+          "includes": "#identifier"
+        }
+      ]
+    },
+    "print-instruction": {
+      "name": "meta.print.kos",
+      "begin": "(?i)\\b(print)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.print.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#print-at-expression"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "print-at-expression": {
+      "begin": "(?i)\\b(at)\\s*\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.at.kos"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#punctuation-comma"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "copy-instruction": {
+      "name": "meta.copy.kos",
+      "begin": "(?i)\\b(copy)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.copy.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#to-from-operators"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "rename-instruction": {
+      "name": "meta.rename.kos",
+      "begin": "(?i)\\b(rename)\\s+\\b(file|volume)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.rename.kos"
+        },
+        "2": {
+          "name": "keyword.other.fileVolume.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#to-operator"
+        }
+      ]
+    },
+    "switch-instruction": {
+      "name": "meta.switch.kos",
+      "begin": "(?i)\\b(switch)\\s+\\b(to)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.switch.kos"
+        },
+        "2": {
+          "name": "keyword.command.switchTo.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "log-instruction": {
+      "begin": "(?i)\\b(log)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.log.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#to-operator"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "delete-instruction": {
+      "name": "meta.delete.kos",
+      "begin": "(?i)\\b(delete)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.delete.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "from-operator"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "compile-instruction": {
+      "name": "meta.compile.kos",
+      "begin": "(?i)\\b(compile)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.compile.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#to-operator"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "run-instruction": {
+      "name": "meta.run.kos",
+      "begin": "(?i)\\b(run)\\s+(?:\\b(once)\\s+)?",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.run.kos"
+        },
+        "2": {
+          "name": "keyword.command.once.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#call"
+        },
+        {
+          "include": "#run-on-instruction"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#file-identiifer"
+        }
+      ]
+    },
+    "run-on-instruction": {
+      "begin": "(?i)\\b(on)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.on.kos"
+        }
+      },
+      "end": "(?=(\\,|\\.))",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "run-path-instruction": {
+      "name": "meta.runpath.kos",
+      "begin": "(?i)\\b(runpath)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.runpath.kos"
+        }
+      },
+      "end": "\\.",
+      "endCapture": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#call"
+        }
+      ]
+    },
+    "run-once-path-instruction": {
+      "name": "meta.runoncepath.kos",
+      "begin": "(?i)\\b(runoncepath)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.runpath.kos"
+        }
+      },
+      "end": "\\.",
+      "endCapture": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#call"
+        }
+      ]
+    },
+    "list-instruction": {
+      "name": "meta.list.kos",
+      "match": "(?i)\\b(list)(?:\\s+\\b([_[:alpha:]][_[:alnum:]]*))?(?:\\s+\\b(in)\\s+\\b([_[:alpha:]][_[:alnum:]]*))?(\\.)",
+      "captures": {
+        "1": {
+          "name": "keyword.command.list.kos"
+        },
+        "2": {
+          "name": "variable.other.kos"
+        },
+        "3": {
+          "name": "keyword.command.in.kos"
+        },
+        "4": {
+          "name": "variable.other.kos"
+        },
+        "5": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      }
+    },
+    "command-instructions": {
+      "patterns": [
+        {
+          "match": "(?i)\\b(clearscreen)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.command.clearscreen.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        },
+        {
+          "match": "(?i)\\b(reboot)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.command.reboot.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        },
+        {
+          "match": "(?i)\\b(shutdown)(\\.)",
+          "captures": {
+            "1": {
+              "name": "keyword.command.shutdown.kos"
+            },
+            "2": {
+              "name": "punctuation.terminator.statement.kos"
+            }
+          }
+        }
+      ]
+    },
+    "node-instructions": {
+      "patterns": [
+        {
+          "include": "#node-add"
+        },
+        {
+          "include": "#node-remove"
+        },
+        {
+          "include": "#node-edit"
+        }
+      ]
+    },
+    "node-add": {
+      "name": "meta.node.add.kos",
+      "begin": "(?i)\\b(add)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.add.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "node-edit": {
+      "name": "meta.node.edit.kos",
+      "begin": "(?i)\\b(edit)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.edit.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "node-remove": {
+      "name": "meta.node.remove.kos",
+      "begin": "(?i)\\b(remove)(?![_[:alnum:]\\:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.command.add.kos"
+        }
+      },
+      "end": "\\.",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.terminator.statement.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#expressions-without-identifiers"
+        },
+        {
+          "include": "#suffix"
+        },
+        {
+          "include": "#white-space"
+        }
+      ]
+    },
+    "expressions-without-identifiers": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#block"
+        },
+        {
+          "include": "#expression-operators"
+        }
+      ]
+    },
+    "expression-operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.expression.or.kos",
+          "match": "(or)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.expression.and.kos",
+          "match": "(and)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.expression.not.kos",
+          "match": "(not)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.expression.defined.kos",
+          "match": "(defined)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.expression.on.kos",
+          "match": "(on)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.expression.off.kos",
+          "match": "(off)(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "keyword.operator.power.kos",
+          "match": "\\^"
+        },
+        {
+          "name": "keyword.operator.comparison.kos",
+          "match": "<>|="
+        },
+        {
+          "name": "keyword.operator.relational.kos",
+          "match": "<=|>=|<|>"
+        },
+        {
+          "name": "keyword.operator.arithmetic.kos",
+          "match": "\\*|/|-|\\+"
+        }
+      ]
+    },
+    "suffix": {
+      "patterns": [
+        {
+          "include": "#function-call"
+        },
+        {
+          "include": "#delegate"
+        },
+        {
+          "include": "#atom"
+        },
+        {
+          "include": "#array-index"
+        },
+        {
+          "include": "#array-brackets"
+        }
+      ]
+    },
+    "array-index": {
+      "match": "(\\#)([0-9]+|([_[:alpha:]][_[:alnum:]]*)(?![_[:alnum:]\\:]))",
+      "captures": {
+        "1": {
+          "name": "meta.pound.kos"
+        },
+        "2": {
+          "name": "variable.parameter.kos"
+        }
+      }
+    },
+    "array-brackets": {
+      "begin": "\\[",
+      "beingCaptures": {
+        "1": {
+          "name": "meta.brace.square.kos"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "1": {
+          "name": "meta.brace.square.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "function-call": {
+      "name": "meta.functioncall.kos",
+      "begin": "(\\:)?([_[:alpha:]][_[:alnum:]]*)\\s*(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.accessor.block.kos"
+        },
+        "2": {
+          "name": "entity.name.function.kos"
+        },
+        "3": {
+          "name": "meta.brace.round.kos"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "1": {
+          "name": "meta.brace.round.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#arguments"
+        }
+      ]
+    },
+    "delegate": {
+      "name": "meta.delegate.kos",
+      "match": "(\\:)?([_[:alpha:]][_[:alnum:]]*)\\s*(\\@)",
+      "captures": {
+        "1": {
+          "name": "punctuation.accessor.block.kos"
+        },
+        "2": {
+          "name": "entity.name.function.kos"
+        },
+        "3": {
+          "name": "meta.atSign.kos"
+        }
+      }
+    },
+    "call": {
+      "name": "meta.call.kos",
+      "begin": "\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "meta.brace.round.kos"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "1": {
+          "name": "meta.brace.round.kos"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#arguments"
+        }
+      ]
+    },
+    "arguments": {
+      "patterns": [
+        {
+          "include": "#punctuation-comma"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "atom": {
+      "patterns": [
+        {
+          "include": "#literal"
+        },
+        {
+          "include": "#file-identiifer"
+        },
+        {
+          "include": "#identifier"
+        },
+        {
+          "include": "#identifier-trailer"
+        },
+        {
+          "include": "#grouping"
+        }
+      ]
+    },
+    "identifier": {
+      "name": "variable.other.identifier.kos",
+      "match": "\\b([_[:alpha:]][_[:alnum:]]*)"
+    },
+    "identifier-trailer": {
+      "name": "variable.other.trailer.kos",
+      "match": "(\\:)([_[:alpha:]][_[:alnum:]]*)(?=(:|\\s))",
+      "captures": {
+        "1": {
+          "name": "punctuation.accessor.block.kos"
+        },
+        "2": {
+          "name": "variable.other.trailer"
+        }
+      }
+    },
+    "file-identifier": {
+      "name": "variable.other.fileIdentifier.kos",
+      "match": "\\b([_[:alpha:]][_[:alnum:]]*(?:\\.[_[:alpha:]][_[:alnum:]]*)+)"
+    },
+    "grouping": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "comment": {
+      "name": "comment.line.double-slash.kos",
+      "begin": "(^[ \\t]+)?(//)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.kos"
+        },
+        "2": {
+          "name": "comment.line.double-slash.kos"
+        }
+      },
+      "contentName": "comment.line.comment.kos",
+      "end": "\\n"
+    },
+    "string": {
+      "name": "string.kos",
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.kos"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.kos"
+        }
+      }
+    },
+    "literal": {
+      "patterns": [
+        {
+          "include": "#numeric-literal"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "name": "constant.language.true.kos",
+          "match": "(?i)\\btrue(?![_[:alnum:]\\:])"
+        },
+        {
+          "name": "constant.language.false.kos",
+          "match": "(?i)\\bfalse(?![_[:alnum:]\\:])"
+        }
+      ]
+    },
+    "to-from-operators": {
+      "patterns": [
+        {
+          "name": "keyword.command.direction.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(to|from)(?![_[:alnum:]\\:])"
+        }
+      ]
+    },
+    "from-operator": {
+      "patterns": [
+        {
+          "name": "keyword.command.from.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(from)(?![_[:alnum:]\\:])"
+        }
+      ]
+    },
+    "to-operator": {
+      "patterns": [
+        {
+          "name": "keyword.command.to.kos",
+          "match": "(?i)(?<![_[:alnum:]\\:])(to)(?![_[:alnum:]\\:])"
+        }
+      ]
+    },
+    "white-space": {
+      "name": "punctuation.separator.whitespace.kos",
+      "match": "\\s"
+    },
+    "numeric-literal": {
+      "name": "constant.numeric.number.kos",
+      "match": "-?(?:0|[1-9](?:[0-9_]*[0-9])?)(?:\\.[0-9](?:[0-9_]*[0-9])?)?(?:[eE][+\\-]?[0-9](?:[0-9_]*[0-9])?)?"
+    },
+    "punctuation-comma": {
+      "name": "punctuation.separator.comma.kos",
+      "match": "\\,"
+    },
+    "punctuation-period": {
+      "name": "punctuation.terminator.statement.kos",
+      "match": "\\."
+    }
+  }
 }

--- a/kerboscripts/parser_valid/unitTests/breaktest.ks
+++ b/kerboscripts/parser_valid/unitTests/breaktest.ks
@@ -1,0 +1,30 @@
+set x to 10.
+until x < 0 {
+    set x to x - 1.
+
+    if x = 3 {
+        break.
+    }
+}
+
+break.
+
+function example {
+    parameter a.
+
+    for i in a {
+        if i = "item" {
+            break.
+        }
+    }
+}
+
+break.
+
+from { local y to 0. } until y > 10 step { set y to y + 1. } do {
+    print(y).
+
+    if y > 20 {
+        break.
+    }
+}

--- a/kerboscripts/parser_valid/unitTests/returntest.ks
+++ b/kerboscripts/parser_valid/unitTests/returntest.ks
@@ -1,0 +1,10 @@
+
+function correct {
+    local function nested {
+        return 20.
+    }
+
+    return nested().
+}
+
+return.

--- a/server/src/analysis/functionScan.ts
+++ b/server/src/analysis/functionScan.ts
@@ -75,8 +75,8 @@ export class FunctionScan extends TreeTraverse {
       // Note this has no logic to detect parameters in loops
       // increment parameter count
       if (node instanceof Decl.Param) {
-        this.result.requiredParameters += node.parameters.length;
-        this.result.optionalParameters += node.defaultParameters.length;
+        this.result.requiredParameters += node.requiredParameters.length;
+        this.result.optionalParameters += node.optionalParameters.length;
       }
 
       return true;

--- a/server/src/analysis/resolver.ts
+++ b/server/src/analysis/resolver.ts
@@ -391,7 +391,7 @@ export class Resolver
       ];
     }
 
-    const setError = this.setVariable(set);
+    const setError = this.setBinding(set);
 
     const useValueErrors = this.useExprLocals(inst.value);
     const useInternalErrors = this.useTokens(used);
@@ -732,7 +732,7 @@ export class Resolver
       return [];
     }
 
-    return this.setVariable(inst.target);
+    return this.setBinding(inst.target);
   }
 
   /**
@@ -755,7 +755,7 @@ export class Resolver
    * Logic for settings a variable. used by set inst and list command
    * @param set token to set
    */
-  private setVariable(set: IToken): Diagnostic[] {
+  private setBinding(set: IToken): Diagnostic[] {
     // if variable isn't defined either report error or define
     let defineError: Maybe<Diagnostic> = undefined;
 

--- a/server/src/analysis/resolver.ts
+++ b/server/src/analysis/resolver.ts
@@ -273,17 +273,17 @@ export class Resolver
     const scopeType = ScopeType.local;
 
     // need to check if default paraemter can really be abbitrary expr
-    const parameterErrors = decl.parameters.map(parameter =>
+    const parameterErrors = decl.requiredParameters.map(parameter =>
       this.tableBuilder.declareParameter(
         scopeType,
         parameter.identifier,
         false,
       ),
     );
-    const defaultParameterErrors = decl.defaultParameters.map(parameter =>
+    const defaultParameterErrors = decl.optionalParameters.map(parameter =>
       this.tableBuilder.declareParameter(scopeType, parameter.identifier, true),
     );
-    const defaultUseErrors = decl.defaultParameters.map(parameter =>
+    const defaultUseErrors = decl.optionalParameters.map(parameter =>
       this.useExprLocals(parameter.value),
     );
 

--- a/server/src/analysis/setResolver.ts
+++ b/server/src/analysis/setResolver.ts
@@ -6,31 +6,71 @@ import { ISetResolverResult, ILocalResult } from './types';
 import { setResult } from './setResult';
 import { empty } from '../utilities/typeGuards';
 
+/**
+ * Identify all local sybmbols used and all used symbols
+ */
 export class SetResolver implements
   IExprVisitor<ISetResolverResult>,
   ISuffixTermVisitor<ISetResolverResult> {
 
+  /**
+   * Set resolver constructor
+   */
   public constructor(public readonly localResolver: LocalResolver) {
   }
 
+  /**
+   * Resolve expression
+   * @param expr expression to resolve
+   */
   public resolveExpr(expr: IExpr): ISetResolverResult {
     return expr.accept(this);
   }
+
+  /**
+   * Resolve suffix term
+   * @param suffixTerm suffix term to resolve
+   */
   public resolveSuffixTerm(suffixTerm: ISuffixTerm): ISetResolverResult {
     return suffixTerm.accept(this);
   }
+
+  /**
+   * Resolve invalid expression, i.e. do nothing
+   * @param _ invalid expression
+   */
   public visitExprInvalid(_: Expr.Invalid): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve binary expresiosn. Binary expression cannot be set
+   * @param _ binary expression
+   */
   public visitBinary(_: Expr.Binary): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve unary expression. Unary expression cannot be set
+   * @param _ unary expression
+   */
   public visitUnary(_: Expr.Unary): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve factor expression. Factor cannot be set.
+   * @param _ factor expression
+   */
   public visitFactor(_: Expr.Factor): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve suffix expression.
+   * @param expr suffix expression
+   */
   public visitSuffix(expr: Expr.Suffix): ISetResolverResult {
     const result = this.resolveSuffixTerm(expr.suffixTerm);
     if (empty(expr.trailer)) {
@@ -40,14 +80,26 @@ export class SetResolver implements
     return setResult(result.set, result.used, this.localResolver.resolveSuffixTerm(expr.trailer));
   }
 
+  /**
+   * Resolve lambda expression. Lambda cannot be set
+   * @param _ lambda expression
+   */
   public visitLambda(_: Expr.Lambda): ISetResolverResult {
     return setResult();
   }
 
+  /**
+   * Resolve invalid suffix term. i.e. do nothing
+   * @param _ invalid suffix term
+   */
   public visitSuffixTermInvalid(_: SuffixTerm.Invalid): ISetResolverResult {
     throw setResult();
   }
 
+  /**
+   * Resolve suffix term trailer
+   * @param expr suffix term trailer
+   */
   public visitSuffixTrailer(expr: SuffixTerm.SuffixTrailer): ISetResolverResult {
     const result = this.resolveSuffixTerm(expr.suffixTerm);
     if (empty(expr.trailer)) {
@@ -57,6 +109,10 @@ export class SetResolver implements
     return setResult(result.set, result.used, this.localResolver.resolveSuffixTerm(expr.trailer));
   }
 
+  /**
+   * Resolve suffix term
+   * @param expr suffix term
+   */
   public visitSuffixTerm(expr: SuffixTerm.SuffixTerm): ISetResolverResult {
     const result = this.resolveSuffixTerm(expr.atom);
     if (expr.trailers.length === 0) {
@@ -67,24 +123,59 @@ export class SetResolver implements
       (acc, curr) => acc.concat(this.localResolver.resolveSuffixTerm(curr)),
       [] as ILocalResult[]));
   }
+
+  /**
+   * Resolve suffix term call trailer
+   * @param _ suffix term call trailer
+   */
   public visitCall(_: SuffixTerm.Call): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve array index trailer
+   * @param _ suffix term array index trailer
+   */
   public visitArrayIndex(_: SuffixTerm.ArrayIndex): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve array bracket trailer
+   * @param _ suffix term array bracket trailer
+   */
   public visitArrayBracket(_: SuffixTerm.ArrayBracket): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve delegate trailer
+   * @param _ suffix term delegate
+   */
   public visitDelegate(_: SuffixTerm.Delegate): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve literal
+   * @param _ literal
+   */
   public visitLiteral(_: SuffixTerm.Literal): ISetResolverResult {
     return setResult();
   }
+
+  /**
+   * Resolve identifier
+   * @param expr identifier suffix term
+   */
   public visitIdentifier(expr: SuffixTerm.Identifier): ISetResolverResult {
     return setResult(expr.token);
   }
+
+  /**
+   * Resolve grouping suffix term. Grouping cannot be set
+   * @param _ grouping suffix term
+   */
   public visitGrouping(_: SuffixTerm.Grouping): ISetResolverResult {
     return setResult();
   }

--- a/server/src/analysis/types.ts
+++ b/server/src/analysis/types.ts
@@ -5,7 +5,7 @@ import { IToken } from '../entities/types';
 import { KsParameter } from '../entities/parameters';
 import { Range, Location } from 'vscode-languageserver';
 import { IArgumentType, IFunctionType } from '../typeChecker/types/types';
-import { IExpr, ISuffixTerm } from '../parser/types';
+import { IExpr, ISuffixTerm, IInst } from '../parser/types';
 
 export const enum SymbolState {
   declared,
@@ -92,6 +92,31 @@ export enum KsSymbolKind {
   lock,
   parameter,
   suffix,
+}
+
+/**
+ * This representing a syntax nod that will be executed later
+ */
+export interface IDeferred {
+  /**
+   * Path to scope
+   */
+  path: IScopePath;
+
+  /**
+   * How many loops deep is the current location
+   */
+  loopDepth: number;
+
+  /**
+   * How many functions deep is the current location
+   */
+  functionDepth: number;
+
+  /**
+   * Node to be executed later
+   */
+  node: IInst | IExpr;
 }
 
 // tslint:disable-next-line:prefer-array-literal

--- a/server/src/parser/declare.ts
+++ b/server/src/parser/declare.ts
@@ -1,5 +1,12 @@
 import { Inst, Block } from './inst';
-import { IDeclScope, IExpr, IInstVisitor, ScopeType, IParameter, IInstPasser } from './types';
+import {
+  IDeclScope,
+  IExpr,
+  IInstVisitor,
+  ScopeType,
+  IParameter,
+  IInstPasser,
+} from './types';
 import { TokenType } from '../entities/tokentypes';
 import { empty } from '../utilities/typeGuards';
 import { IToken } from '../entities/types';
@@ -15,8 +22,8 @@ export abstract class Decl extends Inst {
 export class Scope implements IDeclScope {
   constructor(
     public readonly scope?: IToken,
-    public readonly declare?: IToken) {
-  }
+    public readonly declare?: IToken,
+  ) {}
 
   public toString(): string {
     if (!empty(this.scope) && !empty(this.declare)) {
@@ -36,7 +43,7 @@ export class Scope implements IDeclScope {
 
   public get ranges(): Range[] {
     if (!empty(this.scope) && !empty(this.declare)) {
-      return [this.declare, this.scope]
+      return [this.declare, this.scope];
     }
 
     if (!empty(this.scope)) {
@@ -103,14 +110,16 @@ export class Var extends Decl {
     public readonly identifier: IToken,
     public readonly toIs: IToken,
     public readonly value: IExpr,
-    public readonly scope: IDeclScope) {
+    public readonly scope: IDeclScope,
+  ) {
     super();
   }
 
   public toLines(): string[] {
     const lines = this.value.toLines();
-    lines[0] = `${this.scope.toString()} ${this.identifier.lexeme} `
-      + `${this.toIs.lexeme} ${lines[0]}`;
+    lines[0] =
+      `${this.scope.toString()} ${this.identifier.lexeme} ` +
+      `${this.toIs.lexeme} ${lines[0]}`;
 
     lines[lines.length - 1] = `${lines[lines.length - 1]}.`;
     return lines;
@@ -143,18 +152,22 @@ export class Lock extends Decl {
     public readonly identifier: IToken,
     public readonly to: IToken,
     public readonly value: IExpr,
-    public readonly scope?: IDeclScope) {
+    public readonly scope?: IDeclScope,
+  ) {
     super();
   }
 
   public toLines(): string[] {
     const lines = this.value.toLines();
     if (empty(this.scope)) {
-      lines[0] = `${this.lock.lexeme} ${this.identifier.lexeme} `
-        + `${this.to.lexeme} ${lines[0]}`;
+      lines[0] =
+        `${this.lock.lexeme} ${this.identifier.lexeme} ` +
+        `${this.to.lexeme} ${lines[0]}`;
     } else {
-      lines[0] = `${this.scope.toString()} ${this.lock.lexeme} ${this.identifier.lexeme} `
-        + `${this.to.lexeme} ${lines[0]}`;
+      lines[0] =
+        `${this.scope.toString()} ${this.lock.lexeme} ${
+          this.identifier.lexeme
+        } ` + `${this.to.lexeme} ${lines[0]}`;
     }
 
     lines[lines.length - 1] = `${lines[lines.length - 1]}.`;
@@ -163,9 +176,7 @@ export class Lock extends Decl {
   }
 
   public get start(): Position {
-    return empty(this.scope)
-      ? this.lock.start
-      : this.scope.start;
+    return empty(this.scope) ? this.lock.start : this.scope.start;
   }
 
   public get end(): Position {
@@ -174,17 +185,10 @@ export class Lock extends Decl {
 
   public get ranges(): Range[] {
     if (!empty(this.scope)) {
-      return [
-        this.scope, this.lock,
-        this.identifier, this.to,
-        this.value,
-      ];
+      return [this.scope, this.lock, this.identifier, this.to, this.value];
     }
 
-    return [
-      this.lock, this.identifier,
-      this.to, this.value,
-    ];
+    return [this.lock, this.identifier, this.to, this.value];
   }
 
   public pass<T>(visitor: IInstPasser<T>): T {
@@ -201,23 +205,24 @@ export class Func extends Decl {
     public readonly functionToken: IToken,
     public readonly identifier: IToken,
     public readonly block: Block,
-    public readonly scope?: IDeclScope) {
+    public readonly scope?: IDeclScope,
+  ) {
     super();
   }
 
   public toLines(): string[] {
     const declareLine = empty(this.scope)
       ? `${this.functionToken.lexeme} ${this.identifier.lexeme}`
-      : `${this.scope.toString()} ${this.functionToken.lexeme} ${this.identifier.lexeme}`;
+      : `${this.scope.toString()} ${this.functionToken.lexeme} ${
+          this.identifier.lexeme
+        }`;
 
     const blockLines = this.block.toLines();
     return joinLines(' ', [declareLine], blockLines);
   }
 
   public get start(): Position {
-    return empty(this.scope)
-      ? this.functionToken.start
-      : this.scope.start;
+    return empty(this.scope) ? this.functionToken.start : this.scope.start;
   }
 
   public get end(): Position {
@@ -226,16 +231,10 @@ export class Func extends Decl {
 
   public get ranges(): Range[] {
     if (!empty(this.scope)) {
-      return [
-        this.scope, this.functionToken,
-        this.identifier, this.block,
-      ];
+      return [this.scope, this.functionToken, this.identifier, this.block];
     }
 
-    return [
-      this.functionToken, this.identifier,
-      this.block,
-    ];
+    return [this.functionToken, this.identifier, this.block];
   }
 
   public pass<T>(visitor: IInstPasser<T>): T {
@@ -248,8 +247,7 @@ export class Func extends Decl {
 }
 
 export class Parameter implements IParameter {
-  constructor(
-    public readonly identifier: IToken) { }
+  constructor(public readonly identifier: IToken) {}
 
   public toLines(): string[] {
     return [this.identifier.lexeme];
@@ -276,7 +274,8 @@ export class DefaultParam extends Parameter {
   constructor(
     identifier: IToken,
     public readonly toIs: IToken,
-    public readonly value: IExpr) {
+    public readonly value: IExpr,
+  ) {
     super(identifier);
   }
 
@@ -306,9 +305,10 @@ export class DefaultParam extends Parameter {
 export class Param extends Decl {
   constructor(
     public readonly parameterToken: IToken,
-    public readonly parameters: Parameter[],
-    public readonly defaultParameters: DefaultParam[],
-    public readonly scope?: IDeclScope) {
+    public readonly requiredParameters: Parameter[],
+    public readonly optionalParameters: DefaultParam[],
+    public readonly scope?: IDeclScope,
+  ) {
     super();
   }
 
@@ -318,14 +318,21 @@ export class Param extends Decl {
       : [`${this.scope.toString()} ${this.parameterToken.lexeme}`];
 
     const paramLines = joinLines(
-      ', ', ...this.parameters.map(param => param.toLines()));
+      ', ',
+      ...this.requiredParameters.map(param => param.toLines()),
+    );
     const defaultParamLines = joinLines(
-      ', ', ...this.defaultParameters.map(param => param.toLines()));
+      ', ',
+      ...this.optionalParameters.map(param => param.toLines()),
+    );
 
     let lines: string[] = [];
-    if (this.parameters.length > 0 && this.defaultParameters.length > 0) {
+    if (
+      this.requiredParameters.length > 0 &&
+      this.optionalParameters.length > 0
+    ) {
       lines = joinLines(', ', paramLines, defaultParamLines);
-    } else if (this.parameters.length > 0) {
+    } else if (this.requiredParameters.length > 0) {
       lines = paramLines;
     } else {
       lines = defaultParamLines;
@@ -337,30 +344,29 @@ export class Param extends Decl {
   }
 
   public get start(): Position {
-    return empty(this.scope)
-      ? this.parameterToken.start
-      : this.scope.start;
+    return empty(this.scope) ? this.parameterToken.start : this.scope.start;
   }
 
   public get end(): Position {
-    return this.defaultParameters.length > 0
-      ? this.defaultParameters[this.defaultParameters.length - 1].value.end
-      : this.parameters[this.parameters.length - 1].end;
+    return this.optionalParameters.length > 0
+      ? this.optionalParameters[this.optionalParameters.length - 1].value.end
+      : this.requiredParameters[this.requiredParameters.length - 1].end;
   }
 
   public get ranges(): Range[] {
     if (!empty(this.scope)) {
       return [
-        this.scope, this.parameterToken,
-        ...this.parameters,
-        ...this.defaultParameters,
+        this.scope,
+        this.parameterToken,
+        ...this.requiredParameters,
+        ...this.optionalParameters,
       ];
     }
 
     return [
       this.parameterToken,
-      ...this.parameters,
-      ...this.defaultParameters,
+      ...this.requiredParameters,
+      ...this.optionalParameters,
     ];
   }
 

--- a/server/src/parser/expr.ts
+++ b/server/src/parser/expr.ts
@@ -358,17 +358,29 @@ export class Suffix extends Expr {
     return [this.suffixTerm];
   }
 
-  public endsInCall(): boolean {
+  public isSettable(): boolean {
     // if no trailer check suffix term
     if (empty(this.trailer)) {
-      const suffixTermTrailers = this.suffixTerm.trailers;
+      const { atom, trailers } = this.suffixTerm;
 
       // check for suffix term trailers
-      if (suffixTermTrailers.length > 0) {
-        const lastTrailer = suffixTermTrailers[suffixTermTrailers.length - 1];
-        if (lastTrailer instanceof SuffixTerm.Call) {
+      if (trailers.length > 0) {
+        const lastTrailer = trailers[trailers.length - 1];
+        if (lastTrailer instanceof SuffixTerm.Identifier) {
           return true;
         }
+
+        if (lastTrailer instanceof SuffixTerm.ArrayBracket) {
+          return true;
+        }
+
+        if (lastTrailer instanceof SuffixTerm.ArrayIndex) {
+          return true;
+        }
+      }
+
+      if (atom instanceof SuffixTerm.Identifier) {
+        return true;
       }
 
       return false;
@@ -376,7 +388,7 @@ export class Suffix extends Expr {
 
     // check nested trailers
     if (this.trailer instanceof Suffix) {
-      return this.trailer.endsInCall();
+      return this.trailer.isSettable();
     }
 
     return false;

--- a/server/src/parser/suffixTerm.ts
+++ b/server/src/parser/suffixTerm.ts
@@ -149,25 +149,36 @@ export class SuffixTrailer extends SuffixTermBase {
   /**
    * Method indicating if the suffix ends with a function or suffix call
    */
-  public endsInCall(): boolean {
+  public isSettable(): boolean {
     // if no trailer check suffix term
     if (empty(this.trailer)) {
-      const suffixTermTrailers = this.suffixTerm.trailers;
+      const { atom, trailers } = this.suffixTerm;
 
       // check for suffix term trailers
-      if (suffixTermTrailers.length > 0) {
-        const lastTrailer = suffixTermTrailers[suffixTermTrailers.length - 1];
-        if (lastTrailer instanceof Call) {
+      if (trailers.length > 0) {
+        const lastTrailer = trailers[trailers.length - 1];
+        if (lastTrailer instanceof Identifier) {
+          return true;
+        }
+
+        if (lastTrailer instanceof ArrayBracket) {
+          return true;
+        }
+
+        if (lastTrailer instanceof ArrayIndex) {
           return true;
         }
       }
 
+      if (atom instanceof Identifier) {
+        return true;
+      }
       return false;
     }
 
     // check nested trailers
     if (this.trailer instanceof SuffixTrailer) {
-      return this.trailer.endsInCall();
+      return this.trailer.isSettable();
     }
 
     return false;

--- a/server/src/parser/tokenCheck.ts
+++ b/server/src/parser/tokenCheck.ts
@@ -49,11 +49,11 @@ export class TokenCheck extends TreeExecute<IToken[]> {
         tokens.push(this.instAction(childNode));
       } else if (childNode instanceof Decl.Param) {
         const params = [];
-        for (const param of childNode.parameters) {
+        for (const param of childNode.requiredParameters) {
           params.push(param.identifier);
         }
 
-        for (const param of childNode.defaultParameters) {
+        for (const param of childNode.optionalParameters) {
           params.push(param.identifier);
           params.push(param.toIs);
           params.push(...this.exprAction(param.value));

--- a/server/src/tests/resolver.spec.ts
+++ b/server/src/tests/resolver.spec.ts
@@ -20,6 +20,7 @@ import * as Decl from '../parser/declare';
 import { standardLibraryBuilder } from '../analysis/standardLibrary';
 import { LocalResolver } from '../analysis/localResolver';
 import * as Inst from '../parser/inst';
+import { SetResolver } from '../analysis/setResolver';
 
 const fakeUri = 'C:\\fake.ks';
 
@@ -648,6 +649,38 @@ describe('Local Resolver', () => {
       expect(array.token.lexeme).toBe('array');
       expect(exponent.token.lexeme).toBe('exponent');
       expect(example.token.lexeme).toBe('example');
+
+    } else {
+      expect(true).toBeFalsy();
+    }
+  });
+});
+
+describe('Set Resolver', () => {
+  test('set resolver test 1', () => {
+    const source = 'set Thing(fart):other[used1]:finally(used2, used3):planet to 10.';
+    const result = parseSource(source);
+    noParseErrors(result);
+
+    const { script } = result.parse;
+    const inst = script.insts[0];
+
+    const local = new LocalResolver();
+    const resolver = new SetResolver(local);
+    if (inst instanceof Inst.Set) {
+      const { used, set } = resolver.resolveExpr(inst.suffix);
+      expect(set).not.toBeUndefined();
+      if (!empty(set)) {
+        expect(set.lexeme).toBe('Thing');
+      }
+
+      expect(used.length).toBe(4);
+
+      const [fart, used1, used2, used3] = used;
+      expect(fart.token.lexeme).toBe('fart');
+      expect(used1.token.lexeme).toBe('used1');
+      expect(used2.token.lexeme).toBe('used2');
+      expect(used3.token.lexeme).toBe('used3');
 
     } else {
       expect(true).toBeFalsy();

--- a/server/src/tests/resolver.spec.ts
+++ b/server/src/tests/resolver.spec.ts
@@ -360,7 +360,7 @@ describe('Resolver errors', () => {
   ];
 
   // test basic identifier
-  test('basic list test', () => {
+  test('list command', () => {
     const results = resolveSource(listSource);
 
     expect(0).toBe(results.scan.scanErrors.length);
@@ -391,7 +391,7 @@ describe('Resolver errors', () => {
   ];
 
   // test basic identifier
-  test('basic defined test', () => {
+  test('defined command', () => {
     const defineSource = readFileSync(definedPath, 'utf8');
     const results = resolveSource(defineSource);
 
@@ -420,7 +420,7 @@ describe('Resolver errors', () => {
   ];
 
   // test basic identifier
-  test('basic used test', () => {
+  test('used symbols', () => {
     const usedSource = readFileSync(usedPath, 'utf8');
     const results = resolveSource(usedSource);
 
@@ -445,7 +445,7 @@ describe('Resolver errors', () => {
   ];
 
   // test shadowing
-  test('basic shadowed test', () => {
+  test('shadowed symbols', () => {
     const shadowedSource = readFileSync(shadowPath, 'utf8');
     const results = resolveSource(shadowedSource);
 
@@ -474,7 +474,7 @@ describe('Resolver errors', () => {
   ];
 
   // test deferred resolving
-  test('basic deferred test', () => {
+  test('deferred nodes', () => {
     const deferredSource = readFileSync(deferredPath, 'utf8');
     const results = resolveSource(deferredSource);
 
@@ -484,6 +484,57 @@ describe('Resolver errors', () => {
 
     for (const [error, location] of zip(results.resolveDiagnostics, deferredLocations)) {
       expect(error.severity).toBe(DiagnosticSeverity.Hint);
+      expect(location.start).toEqual(error.range.start);
+      expect(location.end).toEqual(error.range.end);
+    }
+  });
+
+  const breakPath = join(
+    __dirname,
+    '../../../kerboscripts/parser_valid/unitTests/breaktest.ks',
+  );
+
+  const breakLocations: Range[] = [
+    { start: new Marker(9, 0), end: new Marker(9, 5) },
+    { start: new Marker(21, 0), end: new Marker(21, 5) },
+  ];
+
+  // invalid break locations
+  test('break locations', () => {
+    const deferredSource = readFileSync(breakPath, 'utf8');
+    const results = resolveSource(deferredSource);
+
+    expect(results.scan.scanErrors.length).toBe(0);
+    expect(results.parse.parseErrors.length).toBe(0);
+    expect(results.resolveDiagnostics.length > 0).toBe(true);
+
+    for (const [error, location] of zip(results.resolveDiagnostics, breakLocations)) {
+      expect(error.severity).toBe(DiagnosticSeverity.Error);
+      expect(location.start).toEqual(error.range.start);
+      expect(location.end).toEqual(error.range.end);
+    }
+  });
+
+  const returnPath = join(
+    __dirname,
+    '../../../kerboscripts/parser_valid/unitTests/returntest.ks',
+  );
+
+  const returnLocations: Range[] = [
+    { start: new Marker(9, 0), end: new Marker(9, 6) },
+  ];
+
+  // invalid return locations
+  test('return locations', () => {
+    const deferredSource = readFileSync(returnPath, 'utf8');
+    const results = resolveSource(deferredSource);
+
+    expect(results.scan.scanErrors.length).toBe(0);
+    expect(results.parse.parseErrors.length).toBe(0);
+    expect(results.resolveDiagnostics.length > 0).toBe(true);
+
+    for (const [error, location] of zip(results.resolveDiagnostics, returnLocations)) {
+      expect(error.severity).toBe(DiagnosticSeverity.Error);
       expect(location.start).toEqual(error.range.start);
       expect(location.end).toEqual(error.range.end);
     }

--- a/server/src/tests/scanner.spec.ts
+++ b/server/src/tests/scanner.spec.ts
@@ -7,16 +7,18 @@ import { Scanner } from '../scanner/scanner';
 
 const testDir = join(__dirname, '../../../kerboscripts/parser_valid/');
 
-test('scan all', () => {
-  walkDir(testDir, filePath => {
-    const kosFile = readFileSync(filePath, 'utf8');
+describe('Scan all files', () => {
+  test('scan all', () => {
+    walkDir(testDir, filePath => {
+      const kosFile = readFileSync(filePath, 'utf8');
 
-    const scanner = new Scanner(kosFile);
-    const { tokens, scanErrors } = scanner.scanTokens();
-    const errorResult = scanErrors.map(error => ({ filePath, ...error }));
+      const scanner = new Scanner(kosFile);
+      const { tokens, scanErrors } = scanner.scanTokens();
+      const errorResult = scanErrors.map(error => ({ filePath, ...error }));
 
-    expect(tokens.length > 0).toBe(true);
-    expect(errorResult.length === 0).toBe(true);
+      expect(tokens.length > 0).toBe(true);
+      expect(errorResult.length === 0).toBe(true);
+    });
   });
 });
 
@@ -131,15 +133,17 @@ const sequence = [
   TokenType.period,
 ];
 
-test('token sequence', () => {
-  const kosFile = readFileSync(scannerPath, 'utf8');
+describe('Scan test file', () => {
+  test('token sequence', () => {
+    const kosFile = readFileSync(scannerPath, 'utf8');
 
-  const scanner = new Scanner(kosFile);
-  const { tokens, scanErrors } = scanner.scanTokens();
-  expect(scanErrors.length === 0).toBe(true);
+    const scanner = new Scanner(kosFile);
+    const { tokens, scanErrors } = scanner.scanTokens();
+    expect(scanErrors.length === 0).toBe(true);
 
-  for (const [type, token] of zip(sequence, tokens)) {
-    // console.log(`${TokenType[token.type]} vs ${TokenType[type]}`);
-    expect(token.type).toBe(type);
-  }
+    for (const [type, token] of zip(sequence, tokens)) {
+      // console.log(`${TokenType[token.type]} vs ${TokenType[type]}`);
+      expect(token.type).toBe(type);
+    }
+  });
 });

--- a/server/src/typeChecker/coerce.ts
+++ b/server/src/typeChecker/coerce.ts
@@ -1,5 +1,8 @@
 import { IType } from './types/types';
 import { isSubType } from './typeUitlities';
+import { booleanType } from './types/primitives/boolean';
+import { stringType } from './types/primitives/string';
+import { scalarType } from './types/primitives/scalar';
 
 /**
  * Attempt to see if type can be coerced into target type
@@ -7,5 +10,11 @@ import { isSubType } from './typeUitlities';
  * @param target the target of the coercion
  */
 export const coerce = (type: IType, target: IType): boolean => {
+  if (target === booleanType) {
+    return isSubType(type, target)
+      || isSubType(type, stringType)
+      || isSubType(type, scalarType);
+  }
+
   return isSubType(type, target);
 };

--- a/server/src/typeChecker/typeChecker.ts
+++ b/server/src/typeChecker/typeChecker.ts
@@ -89,6 +89,8 @@ export class TypeChecker
   private readonly script: Script;
   private readonly symbolTable: SymbolTable;
 
+  private readonly checkInstBind = this.checkInst.bind(this);
+
   constructor(
     script: Script,
     symbolTable: SymbolTable,
@@ -208,7 +210,7 @@ export class TypeChecker
    * @param insts instruction sto check
    */
   private checkInsts(insts: IInst[]): Diagnostics {
-    return accumulateErrors(insts, this.checkInst.bind(this));
+    return accumulateErrors(insts, this.checkInstBind);
   }
 
   /**
@@ -357,7 +359,7 @@ export class TypeChecker
    * @param inst instruction block
    */
   public visitBlock(inst: Inst.Block): Diagnostics {
-    return accumulateErrors(inst.insts, this.checkInst.bind(this));
+    return accumulateErrors(inst.insts, this.checkInstBind);
   }
 
   /**

--- a/server/src/typeChecker/types/ksType.ts
+++ b/server/src/typeChecker/types/ksType.ts
@@ -13,6 +13,7 @@ import {
   IVariadicType,
   IFunctionType,
   Operator,
+  TypeKind,
 } from './types';
 import { memoize } from '../../utilities/memoize';
 
@@ -60,8 +61,8 @@ export class GenericType implements IGenericBasicType {
     return false;
   }
 
-  public get tag(): 'type' {
-    return 'type';
+  public get tag(): TypeKind.basic {
+    return TypeKind.basic;
   }
 }
 
@@ -135,8 +136,8 @@ export class GenericSuffixType implements IGenericSuffixType {
     return false;
   }
 
-  public get tag(): 'suffix' {
-    return 'suffix';
+  public get tag(): TypeKind.suffix {
+    return TypeKind.suffix;
   }
 }
 
@@ -162,8 +163,8 @@ export class Type implements IBasicType {
     return true;
   }
 
-  public get tag(): 'type' {
-    return 'type';
+  public get tag(): TypeKind.basic {
+    return TypeKind.basic;
   }
 }
 
@@ -194,8 +195,8 @@ export class SuffixType implements ISuffixType {
     return true;
   }
 
-  public get tag(): 'suffix' {
-    return 'suffix';
+  public get tag(): TypeKind.suffix {
+    return TypeKind.suffix;
   }
 }
 
@@ -229,8 +230,8 @@ export class GenericVariadicType implements IGenericVariadicType {
     this.concreteTypes.set(type, newType);
     return newType;
   }
-  public get tag(): 'variadic' {
-    return 'variadic';
+  public get tag(): TypeKind.variadic {
+    return TypeKind.variadic;
   }
 }
 
@@ -244,8 +245,8 @@ export class VariadicType extends GenericVariadicType implements IVariadicType {
   public get fullType(): true {
     return true;
   }
-  public get tag(): 'variadic' {
-    return 'variadic';
+  public get tag(): TypeKind.variadic {
+    return TypeKind.variadic;
   }
 }
 
@@ -268,8 +269,8 @@ export class FunctionType implements IFunctionType {
     return this;
   }
 
-  public get tag(): 'function' {
-    return 'function';
+  public get tag(): TypeKind.function {
+    return TypeKind.function;
   }
 
   public get fullType(): true {

--- a/server/src/typeChecker/types/types.ts
+++ b/server/src/typeChecker/types/types.ts
@@ -4,6 +4,13 @@ interface ITypeMeta<T> {
   toConcreteType(type: IArgumentType): T;
 }
 
+export const enum TypeKind {
+  basic,
+  variadic,
+  suffix,
+  function,
+}
+
 export const enum CallType {
   get,
   set,
@@ -47,17 +54,17 @@ export interface ITemplateSuffixType<TBasicType, TVariadicType, TConcreteType>
 
 export interface IGenericBasicType
   extends ITemplateBasicType<IGenericSuffixType, IArgumentType> {
-  tag: 'type';
+  tag: TypeKind.basic;
 }
 
 export interface IGenericSuffixType
   extends ITemplateSuffixType<IGenericArgumentType, IGenericVariadicType, ISuffixType> {
-  tag: 'suffix';
+  tag: TypeKind.suffix;
 }
 
 export interface IGenericVariadicType extends ITypeMeta<IVariadicType> {
   type: IGenericBasicType;
-  tag: 'variadic';
+  tag: TypeKind.variadic;
 }
 
 export type IGenericArgumentType = IGenericBasicType;
@@ -66,20 +73,20 @@ export interface IBasicType extends IGenericBasicType {
   inherentsFrom?: IArgumentType;
   suffixes: Map<string, ISuffixType>;
   fullType: true;
-  tag: 'type';
+  tag: TypeKind.basic;
 }
 
 export interface ISuffixType extends IGenericSuffixType {
   params: IArgumentType[] | IVariadicType;
   returns: IArgumentType;
   fullType: true;
-  tag: 'suffix';
+  tag: TypeKind.suffix;
 }
 
 export interface IVariadicType extends IGenericVariadicType {
   type: IBasicType;
   fullType: true;
-  tag: 'variadic';
+  tag: TypeKind.variadic;
 }
 
 export type IArgumentType = IBasicType;
@@ -94,7 +101,7 @@ export interface IFunctionType extends ITypeMeta<IFunctionType> {
   params: IArgumentType[] | IVariadicType;
   returns: IArgumentType;
   fullType: true;
-  tag: 'function';
+  tag: TypeKind.function;
 }
 
 export type IType = IArgumentType | IFunctionType | ISuffixType;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This branch introduces new errors related to break and return instructions. Now the language server is aware of breaks that are outside of loops and returns that are outside of functions, providing a relevant error.

This branch also provides a minor syntax update to return where `return expression.` would highlight correctly but not `return.` Additionally there was minor type checker cleanup
