### PR TITLE
Trigger diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+# [0.8.0] (2019-7-7)
+
+## Features
+- **Preserve Diagnostic** report a new error when the preserve keyword appears outside of a trigger scope. Previously preserve wouldn't trigger any warning when it appeared in an inappropriate place
+
+## Bug Fixes
+- **Trigger Return** Previously it returns were reported as error when they appeared inside of a trigger body. The return statement can be used as a more dynamic form of preserve when inside a trigger. It determines when trigger should remain active after its current execution.
+
+
 # [0.7.2] (2019-7-7)
 
 ## Bug Fixes
-- **Error for Empty Files** A bug was introduced as part of the code reorganization that caused an excception to be throw with empty files. This included blank files and files with only withspace or comment. 
+- **Error for Empty Files** A bug was introduced as part of the code reorganization that caused an exception to be throw with empty files. This included blank files and files with only whitespace or comment. 
 
 # [0.7.1] (2019-7-4)
 

--- a/kerboscripts/parser_valid/unitTests/allLanguage.ks
+++ b/kerboscripts/parser_valid/unitTests/allLanguage.ks
@@ -11,6 +11,7 @@ when 10 <> 5 then {
     delete 10 from "someplace".
     switch to 0.
     compile body to 10.
+    preserve.
 }
 
 toggle ship:panels.
@@ -67,7 +68,6 @@ log choose 10 if body:atm:exists else 5 to dump.txt.
 
 stage.
 clearScreen.
-preserve.
 reboot.
 shutdown.
 

--- a/kerboscripts/parser_valid/unitTests/preservetest.ks
+++ b/kerboscripts/parser_valid/unitTests/preservetest.ks
@@ -1,0 +1,24 @@
+
+function correct {
+    preserve.
+}
+
+local a is {
+    print(a).
+    preserve.
+}.
+
+when 5 > 10 then {
+    preserve.
+}
+
+for i in range(10) {
+    print(i).
+    preserve.
+}
+
+on true {
+    preserve.
+}
+
+preserve.

--- a/kerboscripts/parser_valid/unitTests/returntest.ks
+++ b/kerboscripts/parser_valid/unitTests/returntest.ks
@@ -11,6 +11,18 @@ local a is {
     return.
 }.
 
+local x is 10.
+
+when x > 10 then {
+    return true.
+}
+
+on true {
+    return true.
+}
+
 if a {
     return.
 }
+
+return "exit".

--- a/server/src/analysis/types.ts
+++ b/server/src/analysis/types.ts
@@ -188,6 +188,11 @@ export interface IDeferred {
   functionDepth: number;
 
   /**
+   * How many triggers deep is the current location
+   */
+  triggerDepth: number;
+
+  /**
    * Node to be executed later
    */
   node: IStmt | IExpr;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This bug add new diagnostics for the `preserve.` keyword. This indicates when preserve appears outside of a trigger body. This pr also fixes #68 where it was reported as an error when a `return` would appear inside trigger.  