### PR TITLE
Operator update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+# [0.8.0] (2019-7-7)
+
+## Features
+- **Preserve Diagnostic** report a new error when the preserve keyword appears outside of a trigger scope. Previously preserve wouldn't trigger any warning when it appeared in an inappropriate place
+
+## Bug Fixes
+- **Trigger Return** Previously it returns were reported as error when they appeared inside of a trigger body. The return statement can be used as a more dynamic form of preserve when inside a trigger. It determines when trigger should remain active after its current execution.
+
+
 # [0.7.2] (2019-7-7)
 
 ## Bug Fixes
-- **Error for Empty Files** A bug was introduced as part of the code reorganization that caused an excception to be throw with empty files. This included blank files and files with only withspace or comment. 
+- **Error for Empty Files** A bug was introduced as part of the code reorganization that caused an exception to be throw with empty files. This included blank files and files with only whitespace or comment. 
 
 # [0.7.1] (2019-7-4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 - **Preserve Diagnostic** report a new error when the preserve keyword appears outside of a trigger scope. Previously preserve wouldn't trigger any warning when it appeared in an inappropriate place
 
+- **Improved Operator Type Checking** The internal type checker has been improved to better represent operators inside of kerboscript.
+
 ## Bug Fixes
 - **Trigger Return** Previously it returns were reported as error when they appeared inside of a trigger body. The return statement can be used as a more dynamic form of preserve when inside a trigger. It determines when trigger should remain active after its current execution.
 

--- a/kerboscripts/parser_valid/unitTests/allLanguage.ks
+++ b/kerboscripts/parser_valid/unitTests/allLanguage.ks
@@ -11,6 +11,7 @@ when 10 <> 5 then {
     delete 10 from "someplace".
     switch to 0.
     compile body to 10.
+    preserve.
 }
 
 toggle ship:panels.
@@ -67,7 +68,6 @@ log choose 10 if body:atm:exists else 5 to dump.txt.
 
 stage.
 clearScreen.
-preserve.
 reboot.
 shutdown.
 

--- a/kerboscripts/parser_valid/unitTests/preservetest.ks
+++ b/kerboscripts/parser_valid/unitTests/preservetest.ks
@@ -1,0 +1,24 @@
+
+function correct {
+    preserve.
+}
+
+local a is {
+    print(a).
+    preserve.
+}.
+
+when 5 > 10 then {
+    preserve.
+}
+
+for i in range(10) {
+    print(i).
+    preserve.
+}
+
+on true {
+    preserve.
+}
+
+preserve.

--- a/kerboscripts/parser_valid/unitTests/returntest.ks
+++ b/kerboscripts/parser_valid/unitTests/returntest.ks
@@ -11,6 +11,18 @@ local a is {
     return.
 }.
 
+local x is 10.
+
+when x > 10 then {
+    return true.
+}
+
+on true {
+    return true.
+}
+
 if a {
     return.
 }
+
+return "exit".

--- a/server/src/analysis/types.ts
+++ b/server/src/analysis/types.ts
@@ -188,6 +188,11 @@ export interface IDeferred {
   functionDepth: number;
 
   /**
+   * How many triggers deep is the current location
+   */
+  triggerDepth: number;
+
+  /**
    * Node to be executed later
    */
   node: IStmt | IExpr;

--- a/server/src/tests/typeChecking.spec.ts
+++ b/server/src/tests/typeChecking.spec.ts
@@ -346,6 +346,30 @@ print(d2).
 print(t1).
 `;
 
+const binaryAdditionSource = `
+local s1 is 10 + 10.
+local str1 is "cat" + "dog".
+
+local v1 is v(1, 1, 1) + v(1, 1, 1).
+
+local d1 is q(1, 1, 1, 1) + v(1, 1, 1).
+local d2 is q(1, 1, 1, 1) + q(1, 1, 1, 1).
+
+local t1 is time + time.
+local t2 is time + 10.
+
+print(s1).
+print(str1).
+
+print(v1).
+
+print(d1).
+print(d2).
+
+print(t1).
+print(t2).
+`;
+
 describe('Operators', () => {
   test('unary operators', () => {
     const results = checkSource(unarySource, true);
@@ -424,5 +448,28 @@ describe('Operators', () => {
     symbolTests(names, 'd2', KsSymbolKind.variable, directionType);
 
     symbolTests(names, 't1', KsSymbolKind.variable, timeSpanType);
+  });
+
+  test('binary plus operators', () => {
+    const results = checkSource(binaryAdditionSource, true);
+    noErrors(results);
+
+    const { table } = results;
+    const symbols = table.fileSymbols();
+    const names = new Map(
+      symbols.map((s): [string, KsBaseSymbol] => [s.name.lexeme, s]),
+    );
+
+    symbolTests(names, 's1', KsSymbolKind.variable, scalarType);
+
+    symbolTests(names, 'str1', KsSymbolKind.variable, stringType);
+
+    symbolTests(names, 'v1', KsSymbolKind.variable, vectorType);
+
+    symbolTests(names, 'd1', KsSymbolKind.variable, vectorType);
+    symbolTests(names, 'd2', KsSymbolKind.variable, directionType);
+
+    symbolTests(names, 't1', KsSymbolKind.variable, timeSpanType);
+    symbolTests(names, 't2', KsSymbolKind.variable, timeSpanType);
   });
 });

--- a/server/src/tests/typeChecking.spec.ts
+++ b/server/src/tests/typeChecking.spec.ts
@@ -27,6 +27,7 @@ import { vectorType } from '../typeChecker/types/collections/vector';
 import { directionType } from '../typeChecker/types/direction';
 import { Marker } from '../entities/marker';
 import { zip } from '../utilities/arrayUtils';
+import { timeSpanType } from '../typeChecker/types/timespan';
 
 const fakeUri = 'C:\\fake.ks';
 
@@ -323,6 +324,28 @@ print(b1).
 print(n1).
 `;
 
+const binaryMultiplicationSource = `
+local s1 is 10 * 10.
+
+local v1 is v(1, 1, 1) * v(1, 1, 1).
+local v2 is v(1, 1, 1) * 10.
+
+local d1 is q(1, 1, 1, 1) * v(1, 1, 1).
+local d2 is q(1, 1, 1, 1) * q(1, 1, 1, 1).
+
+local t1 is time * 10.
+
+print(s1).
+
+print(v1).
+print(v2).
+
+print(d1).
+print(d2).
+
+print(t1).
+`;
+
 describe('Operators', () => {
   test('unary operators', () => {
     const results = checkSource(unarySource, true);
@@ -380,5 +403,26 @@ describe('Operators', () => {
       expect(location.start).toEqual(error.range.start);
       expect(location.end).toEqual(error.range.end);
     }
+  });
+
+  test('binary multiplication operators', () => {
+    const results = checkSource(binaryMultiplicationSource, true);
+    noErrors(results);
+
+    const { table } = results;
+    const symbols = table.fileSymbols();
+    const names = new Map(
+      symbols.map((s): [string, KsBaseSymbol] => [s.name.lexeme, s]),
+    );
+
+    symbolTests(names, 's1', KsSymbolKind.variable, scalarType);
+
+    symbolTests(names, 'v1', KsSymbolKind.variable, scalarType);
+    symbolTests(names, 'v2', KsSymbolKind.variable, vectorType);
+
+    symbolTests(names, 'd1', KsSymbolKind.variable, vectorType);
+    symbolTests(names, 'd2', KsSymbolKind.variable, directionType);
+
+    symbolTests(names, 't1', KsSymbolKind.variable, timeSpanType);
   });
 });

--- a/server/src/tests/typeCheckingUtilities.spec.ts
+++ b/server/src/tests/typeCheckingUtilities.spec.ts
@@ -60,7 +60,7 @@ describe('Type Utilities', () => {
     expect(isSubType(booleanType, partType)).toBe(false);
     expect(isSubType(booleanType, dockingPortType)).toBe(false);
 
-    expect(isSubType(structureType, booleanType)).toBe(false);
+    expect(isSubType(structureType, stringType)).toBe(true);
     expect(isSubType(structureType, booleanType)).toBe(false);
     expect(isSubType(structureType, structureType)).toBe(true);
     expect(isSubType(structureType, partType)).toBe(false);

--- a/server/src/tests/typeCheckingUtilities.spec.ts
+++ b/server/src/tests/typeCheckingUtilities.spec.ts
@@ -60,7 +60,7 @@ describe('Type Utilities', () => {
     expect(isSubType(booleanType, partType)).toBe(false);
     expect(isSubType(booleanType, dockingPortType)).toBe(false);
 
-    expect(isSubType(structureType, stringType)).toBe(true);
+    expect(isSubType(structureType, stringType)).toBe(false);
     expect(isSubType(structureType, booleanType)).toBe(false);
     expect(isSubType(structureType, structureType)).toBe(true);
     expect(isSubType(structureType, partType)).toBe(false);

--- a/server/src/typeChecker/coerce.ts
+++ b/server/src/typeChecker/coerce.ts
@@ -3,18 +3,29 @@ import { isSubType } from './typeUitlities';
 import { booleanType } from './types/primitives/boolean';
 import { stringType } from './types/primitives/string';
 import { scalarType } from './types/primitives/scalar';
+import { TypeKind } from './types';
+import { structureType } from './types/primitives/structure';
 
 /**
  * Attempt to see if type can be coerced into target type
- * @param type type in question
- * @param target the target of the coercion
+ * @param queryType type in question
+ * @param targetType the target of the coercion
  */
-export const coerce = (type: Type, target: Type): boolean => {
-  if (target === booleanType) {
-    return isSubType(type, target)
-      || isSubType(type, stringType)
-      || isSubType(type, scalarType);
+export const coerce = (queryType: Type, targetType: Type): boolean => {
+  if (targetType === booleanType) {
+    return (
+      isSubType(queryType, targetType) ||
+      isSubType(queryType, stringType) ||
+      isSubType(queryType, scalarType)
+    );
   }
 
-  return isSubType(type, target);
+  // if target type is basic and query is a structure
+  // we can assume that structure ~ any so for the type checker
+  // it is coercible
+  if (targetType.kind === TypeKind.basic && queryType === structureType) {
+    return true;
+  }
+
+  return isSubType(queryType, targetType);
 };

--- a/server/src/typeChecker/ksType.ts
+++ b/server/src/typeChecker/ksType.ts
@@ -15,6 +15,7 @@ import { SuffixTracker } from '../analysis/suffixTracker';
 import { KsSuffix } from '../entities/suffix';
 import { tType } from './typeCreators';
 import { OperatorKind, TypeKind, CallKind } from './types';
+import { Operator } from './operator';
 
 /**
  * This represents a generic type, typically the containers of kos
@@ -28,7 +29,7 @@ export class GenericBasicType implements IGenericBasicType {
   /**
    * Operators that are applicable for this type
    */
-  public operators: Map<OperatorKind, IBasicType>;
+  public operators: Map<OperatorKind, Operator[]>;
 
   /**
    * Suffixes attach to this type
@@ -227,7 +228,7 @@ export class BasicType implements IBasicType {
   /**
    * Operators that are applicable for this type
    */
-  public operators: Map<OperatorKind, IBasicType>;
+  public operators: Map<OperatorKind, Operator[]>;
 
   /**
    * Is this type a subtype of another type

--- a/server/src/typeChecker/ksType.ts
+++ b/server/src/typeChecker/ksType.ts
@@ -22,7 +22,7 @@ import { Operator } from './operator';
  */
 export class GenericBasicType implements IGenericBasicType {
   /**
-   * A memoized mapping of this genertic type to concrete types
+   * A memoized mapping of this generic type to concrete types
    */
   private concreteTypes: Map<ArgumentType, IBasicType>;
 
@@ -268,7 +268,9 @@ export class BasicType implements IBasicType {
       return this.name;
     }
 
-    const typeParameterStr = this.typeParameters.map(t => t.toTypeString()).join(', ');
+    const typeParameterStr = this.typeParameters
+      .map(t => t.toTypeString())
+      .join(', ');
     return `${this.name}<${typeParameterStr}>`;
   }
 
@@ -318,9 +320,10 @@ export class SuffixType implements ISuffixType {
    * Generate the type string for this suffix type
    */
   public toTypeString(): string {
-    const typeParameterStr = this.typeParameters.length > 0
-      ? `<${this.typeParameters.map(t => t.toTypeString()).join(', ')}>`
-      : '';
+    const typeParameterStr =
+      this.typeParameters.length > 0
+        ? `<${this.typeParameters.map(t => t.toTypeString()).join(', ')}>`
+        : '';
 
     const returnString = returnTypeString(this.returns);
     if (

--- a/server/src/typeChecker/operator.ts
+++ b/server/src/typeChecker/operator.ts
@@ -1,5 +1,6 @@
 import { ArgumentType } from './types/types';
 import { OperatorKind } from './types';
+import { empty } from '../utilities/typeGuards';
 
 export class Operator {
   /**
@@ -10,7 +11,7 @@ export class Operator {
   /**
    * What is the other operand for this operator
    */
-  public readonly otherOperand: ArgumentType;
+  public readonly otherOperand?: ArgumentType;
 
   /**
    * What is the return type of this operator
@@ -24,11 +25,19 @@ export class Operator {
    * @param returnType what is the return type of this operation
    */
   constructor(
-      operator: OperatorKind,
-      otherOperand: ArgumentType,
-      returnType: ArgumentType) {
+    operator: OperatorKind,
+    returnType: ArgumentType,
+    otherOperand?: ArgumentType,
+  ) {
     this.operator = operator;
     this.otherOperand = otherOperand;
     this.returnType = returnType;
+  }
+
+  /**
+   * Is the operator a unary operator
+   */
+  public isUnary(): boolean {
+    return empty(this.otherOperand);
   }
 }

--- a/server/src/typeChecker/operator.ts
+++ b/server/src/typeChecker/operator.ts
@@ -1,0 +1,34 @@
+import { ArgumentType } from './types/types';
+import { OperatorKind } from './types';
+
+export class Operator {
+  /**
+   * What operator kind associated with this operator
+   */
+  public readonly operator: OperatorKind;
+
+  /**
+   * What is the other operand for this operator
+   */
+  public readonly otherOperand: ArgumentType;
+
+  /**
+   * What is the return type of this operator
+   */
+  public readonly returnType: ArgumentType;
+
+  /**
+   * Construct and instance of an operator
+   * @param operator what is the operator kind
+   * @param otherOperand what else need to appear in this operation
+   * @param returnType what is the return type of this operation
+   */
+  constructor(
+      operator: OperatorKind,
+      otherOperand: ArgumentType,
+      returnType: ArgumentType) {
+    this.operator = operator;
+    this.otherOperand = otherOperand;
+    this.returnType = returnType;
+  }
+}

--- a/server/src/typeChecker/typeChecker.ts
+++ b/server/src/typeChecker/typeChecker.ts
@@ -1053,8 +1053,23 @@ export class TypeChecker
           type: booleanType,
         };
 
-      case TokenType.minus:
       case TokenType.not:
+        if (!coerce(result.type, booleanType)) {
+          errors.push(
+            createDiagnostic(
+              expr.factor,
+              'Can only apply not operator to booleans',
+              DiagnosticSeverity.Hint,
+            ),
+          );
+        }
+
+        return {
+          errors,
+          type: booleanType,
+        };
+
+      case TokenType.minus:
       case TokenType.plus:
         const operatorKind = operatorMap.get(expr.operator.type);
         if (!empty(operatorKind)) {
@@ -1327,7 +1342,7 @@ export class TypeChecker
         createDiagnostic(
           call.close,
           `Function expected ${params.length} parameters but was called with ${
-            call.args
+            call.args.length
           } arguments`,
           DiagnosticSeverity.Hint,
         ),
@@ -1595,7 +1610,7 @@ export class TypeChecker
         suffixTerm.token.lookup,
       );
 
-      // may need to pass sommething in about if we're in get set context
+      // may need to pass something in about if we're in get set context
       if (!empty(suffix)) {
         // assign type tracker
         suffixTerm.token.tracker = suffix.getTracker();

--- a/server/src/typeChecker/typeUitlities.ts
+++ b/server/src/typeChecker/typeUitlities.ts
@@ -249,9 +249,9 @@ export const addPrototype = <T extends IGenericBasicType>(
  */
 export const addOperators = <T extends IGenericBasicType>(
   type: T,
-  ...operators: [OperatorKind, IBasicType][]
+  ...operators: { operator: OperatorKind, other: ArgumentType, returnType: ArgumentType }[]
 ): void => {
-  for (const [operator, returnType] of operators) {
+  for (const {operator, other, returnType } of operators) {
     if (type.operators.has(operator)) {
       throw new Error(`duplicate operator ${operator} added to type`);
     }
@@ -259,6 +259,8 @@ export const addOperators = <T extends IGenericBasicType>(
     type.operators.set(operator, returnType);
   }
 };
+
+
 
 /**
  * Add suffixes to type

--- a/server/src/typeChecker/typeUitlities.ts
+++ b/server/src/typeChecker/typeUitlities.ts
@@ -22,6 +22,7 @@ import {
   UnaryConstructor,
 } from './types';
 import { Operator } from './operator';
+import { structureType } from './types/primitives/structure';
 
 /**
  * This map token types to operator kinds
@@ -143,6 +144,10 @@ export const hasOperator = (
  * @param suffix suffix string
  */
 export const hasSuffix = (type: Type, suffix: string): boolean => {
+  if (type === structureType) {
+    return true;
+  }
+
   if (type.kind === TypeKind.basic) {
     return moveUpSuperTypes(type, false, currentType => {
       if (currentType.suffixes.has(suffix)) {
@@ -172,7 +177,7 @@ export const getSuffix = (type: Type, suffix: string): Maybe<ISuffixType> => {
 };
 
 /**
- * Retreive all suffixes from the given type
+ * Retrieve all suffixes from the given type
  * @param type type
  */
 export const allSuffixes = (type: Type): ISuffixType[] => {

--- a/server/src/typeChecker/typeUitlities.ts
+++ b/server/src/typeChecker/typeUitlities.ts
@@ -22,14 +22,11 @@ import {
   UnaryConstructor,
 } from './types';
 import { Operator } from './operator';
-import { structureType } from './types/primitives/structure';
 
 /**
- * This map token types to operator kinds
+ * This map token types to binary operator kinds
  */
-export const operatorMap: Map<TokenType, OperatorKind> = new Map([
-  [TokenType.not, OperatorKind.not],
-  [TokenType.defined, OperatorKind.defined],
+export const binaryOperatorMap: Map<TokenType, OperatorKind> = new Map([
   [TokenType.minus, OperatorKind.subtract],
   [TokenType.multi, OperatorKind.multiply],
   [TokenType.div, OperatorKind.divide],
@@ -42,6 +39,16 @@ export const operatorMap: Map<TokenType, OperatorKind> = new Map([
   [TokenType.or, OperatorKind.or],
   [TokenType.equal, OperatorKind.equal],
   [TokenType.notEqual, OperatorKind.notEqual],
+]);
+
+/**
+ * This maps tokens types to unary operator kinds
+ */
+export const unaryOperatorMap: Map<TokenType, OperatorKind> = new Map([
+  [TokenType.not, OperatorKind.not],
+  [TokenType.defined, OperatorKind.defined],
+  [TokenType.minus, OperatorKind.negate],
+  [TokenType.plus, OperatorKind.negate],
 ]);
 
 /**
@@ -144,10 +151,6 @@ export const hasOperator = (
  * @param suffix suffix string
  */
 export const hasSuffix = (type: Type, suffix: string): boolean => {
-  if (type === structureType) {
-    return true;
-  }
-
   if (type.kind === TypeKind.basic) {
     return moveUpSuperTypes(type, false, currentType => {
       if (currentType.suffixes.has(suffix)) {

--- a/server/src/typeChecker/types.ts
+++ b/server/src/typeChecker/types.ts
@@ -1,4 +1,4 @@
-import { Type } from './types/types';
+import { Type, ArgumentType } from './types/types';
 import { Diagnostic } from 'vscode-languageserver';
 import { SuffixTypeBuilder } from './suffixTypeNode';
 
@@ -20,7 +20,9 @@ export interface ITypeResultExpr<T extends Type> {
 /**
  * type result for a kerboscript suffix
  */
-export interface ITypeResultSuffix<T extends SuffixTypeBuilder = SuffixTypeBuilder> {
+export interface ITypeResultSuffix<
+  T extends SuffixTypeBuilder = SuffixTypeBuilder
+> {
   /**
    * resolved cummulative suffix types
    */
@@ -53,9 +55,67 @@ export const enum CallKind {
 }
 
 /**
+ * Construct a binary operation for a given type
+ */
+export interface BinaryConstructor {
+  /**
+   * What is the operator
+   */
+  operator:
+    | OperatorKind.and
+    | OperatorKind.or
+    | OperatorKind.plus
+    | OperatorKind.subtract
+    | OperatorKind.multiply
+    | OperatorKind.divide
+    | OperatorKind.power
+    | OperatorKind.greaterThan
+    | OperatorKind.lessThan
+    | OperatorKind.greaterThanEqual
+    | OperatorKind.lessThanEqual
+    | OperatorKind.notEqual
+    | OperatorKind.equal;
+
+  /**
+   * What is the return type of this operator
+   */
+  returnType: ArgumentType;
+
+  /**
+   * What is the other type of the operator
+   */
+  other: ArgumentType;
+}
+
+/**
+ * Construct a unary operation for a given type
+ */
+export interface UnaryConstructor {
+  /**
+   * What is the operator
+   */
+  operator: OperatorKind.negate | OperatorKind.defined | OperatorKind.not;
+
+  /**
+   * What is the return type of this operator
+   */
+  returnType: ArgumentType;
+
+  /**
+   * What is the other type of this operator
+   */
+  other: undefined;
+}
+
+/**
  * What operator kind is present
  */
-export const enum OperatorKind {
+export enum OperatorKind {
+  not,
+  defined,
+  negate,
+  and,
+  or,
   plus,
   subtract,
   multiply,
@@ -67,5 +127,4 @@ export const enum OperatorKind {
   lessThanEqual,
   notEqual,
   equal,
-  boolean,
 }

--- a/server/src/typeChecker/types.ts
+++ b/server/src/typeChecker/types.ts
@@ -94,7 +94,7 @@ export interface UnaryConstructor {
   /**
    * What is the operator
    */
-  operator: OperatorKind.negate | OperatorKind.defined | OperatorKind.not;
+  operator: OperatorKind.negate;
 
   /**
    * What is the return type of this operator

--- a/server/src/typeChecker/types/collections/vector.ts
+++ b/server/src/typeChecker/types/collections/vector.ts
@@ -1,8 +1,14 @@
 import { ArgumentType } from '../types';
-import { createSetSuffixType, createSuffixType, createStructureType } from "../../typeCreators";
-import { addPrototype, addSuffixes } from '../../typeUitlities';
+import {
+  createSetSuffixType,
+  createSuffixType,
+  createStructureType,
+} from '../../typeCreators';
+import { addPrototype, addSuffixes, addOperators } from '../../typeUitlities';
 import { scalarType } from '../primitives/scalar';
 import { serializableStructureType } from '../primitives/serializeableStructure';
+import { OperatorKind } from '../../types';
+import { booleanType } from '../primitives/boolean';
 
 export const vectorType: ArgumentType = createStructureType('vector');
 addPrototype(vectorType, serializableStructureType);
@@ -17,4 +23,48 @@ addSuffixes(
   createSuffixType('normalized', vectorType),
   createSuffixType('sqrMagnitude', scalarType),
   createSetSuffixType('direction', scalarType),
+);
+
+addOperators(
+  vectorType,
+  {
+    operator: OperatorKind.plus,
+    returnType: vectorType,
+    other: vectorType,
+  },
+  {
+    operator: OperatorKind.subtract,
+    returnType: vectorType,
+    other: vectorType,
+  },
+  {
+    operator: OperatorKind.multiply,
+    returnType: scalarType,
+    other: vectorType,
+  },
+  {
+    operator: OperatorKind.multiply,
+    returnType: vectorType,
+    other: scalarType,
+  },
+  {
+    operator: OperatorKind.divide,
+    returnType: vectorType,
+    other: scalarType,
+  },
+  {
+    operator: OperatorKind.equal,
+    returnType: booleanType,
+    other: vectorType,
+  },
+  {
+    operator: OperatorKind.notEqual,
+    returnType: booleanType,
+    other: vectorType,
+  },
+  {
+    operator: OperatorKind.negate,
+    returnType: booleanType,
+    other: undefined,
+  },
 );

--- a/server/src/typeChecker/types/collections/vector.ts
+++ b/server/src/typeChecker/types/collections/vector.ts
@@ -64,7 +64,7 @@ addOperators(
   },
   {
     operator: OperatorKind.negate,
-    returnType: booleanType,
+    returnType: vectorType,
     other: undefined,
   },
 );

--- a/server/src/typeChecker/types/direction.ts
+++ b/server/src/typeChecker/types/direction.ts
@@ -1,9 +1,11 @@
 import { ArgumentType } from './types';
 import { createStructureType, createSuffixType } from '../typeCreators';
-import { addPrototype, addSuffixes } from '../typeUitlities';
+import { addPrototype, addSuffixes, addOperators } from '../typeUitlities';
 import { vectorType } from './collections/vector';
 import { scalarType } from './primitives/scalar';
 import { serializableStructureType } from './primitives/serializeableStructure';
+import { OperatorKind } from '../types';
+import { booleanType } from './primitives/boolean';
 
 export const directionType: ArgumentType = createStructureType('direction');
 addPrototype(directionType, serializableStructureType);
@@ -20,4 +22,48 @@ addSuffixes(
   createSuffixType('starVector', vectorType),
   createSuffixType('rightVector', vectorType),
   createSuffixType('inverse', directionType),
+);
+
+addOperators(
+  directionType,
+  {
+    operator: OperatorKind.multiply,
+    other: directionType,
+    returnType: directionType,
+  },
+  {
+    operator: OperatorKind.multiply,
+    other: vectorType,
+    returnType: vectorType,
+  },
+  {
+    operator: OperatorKind.plus,
+    other: vectorType,
+    returnType: vectorType,
+  },
+  {
+    operator: OperatorKind.plus,
+    other: directionType,
+    returnType: directionType,
+  },
+  {
+    operator: OperatorKind.subtract,
+    other: directionType,
+    returnType: directionType,
+  },
+  {
+    operator: OperatorKind.equal,
+    other: directionType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.notEqual,
+    other: directionType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.negate,
+    returnType: booleanType,
+    other: undefined,
+  },
 );

--- a/server/src/typeChecker/types/direction.ts
+++ b/server/src/typeChecker/types/direction.ts
@@ -63,7 +63,7 @@ addOperators(
   },
   {
     operator: OperatorKind.negate,
-    returnType: booleanType,
+    returnType: directionType,
     other: undefined,
   },
 );

--- a/server/src/typeChecker/types/io/path.ts
+++ b/server/src/typeChecker/types/io/path.ts
@@ -6,7 +6,7 @@ import {
   createVarSuffixType,
   createVarType,
 } from '../../typeCreators';
-import { addPrototype, addSuffixes } from '../../typeUitlities';
+import { addPrototype, addSuffixes, addOperators } from '../../typeUitlities';
 import { structureType } from '../primitives/structure';
 import { volumeType } from './volume';
 import { integerType } from '../primitives/scalar';
@@ -14,6 +14,7 @@ import { stringType } from '../primitives/string';
 import { booleanType } from '../primitives/boolean';
 import { serializableStructureType } from '../primitives/serializeableStructure';
 import { listType } from '../collections/list';
+import { OperatorKind } from '../../types';
 
 export const pathType: ArgumentType = createStructureType('path');
 addPrototype(pathType, serializableStructureType);
@@ -32,4 +33,18 @@ addSuffixes(
   createArgSuffixType('changeName', pathType, stringType),
   createArgSuffixType('changeExtension', pathType, stringType),
   createVarSuffixType('combine', pathType, createVarType(structureType)),
+);
+
+addOperators(
+  pathType,
+  {
+    operator: OperatorKind.equal,
+    other: pathType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.notEqual,
+    other: pathType,
+    returnType: booleanType,
+  },
 );

--- a/server/src/typeChecker/types/io/volume.ts
+++ b/server/src/typeChecker/types/io/volume.ts
@@ -1,5 +1,10 @@
 import { ArgumentType } from '../types';
-import { createStructureType, createArgSuffixType, createSuffixType, createSetSuffixType } from "../../typeCreators";
+import {
+  createStructureType,
+  createArgSuffixType,
+  createSuffixType,
+  createSetSuffixType,
+} from '../../typeCreators';
 import { addPrototype, addSuffixes } from '../../typeUitlities';
 import { structureType } from '../primitives/structure';
 import { volumeDirectoryType } from './volumeDirectory';

--- a/server/src/typeChecker/types/orbital/initialize.ts
+++ b/server/src/typeChecker/types/orbital/initialize.ts
@@ -1,4 +1,4 @@
-import { addPrototype, addSuffixes } from '../../typeUitlities';
+import { addPrototype, addSuffixes, addOperators } from '../../typeUitlities';
 import { orbitableType } from './orbitable';
 import { serializableStructureType } from '../primitives/serializeableStructure';
 import { createSuffixType, createArgSuffixType } from '../../typeCreators';
@@ -29,6 +29,7 @@ import { vesselTargetType } from './vesselTarget';
 import { partModuleType } from '../parts/partModule';
 import { crewType } from '../crew';
 import { vesselSensorsType } from '../vessel/vesselSensors';
+import { OperatorKind } from '../../types';
 
 let set = false;
 
@@ -75,7 +76,10 @@ export const orbitalInitializer = () => {
     createSuffixType('mass', scalarType),
     createSuffixType('hasOcean', booleanType),
     createSuffixType('hasSolidSurface', booleanType),
-    createSuffixType('orbitingChildren', listType.toConcreteType(bodyTargetType)),
+    createSuffixType(
+      'orbitingChildren',
+      listType.toConcreteType(bodyTargetType),
+    ),
     createSuffixType('altitude', scalarType),
     createSuffixType('radius', scalarType),
     createSuffixType('mu', scalarType),
@@ -86,26 +90,92 @@ export const orbitalInitializer = () => {
     createSuffixType('rotationAngle', scalarType),
     createArgSuffixType('geoPositionOf', geoCoordinatesType, vectorType),
     createArgSuffixType('altitudeOf', scalarType, vectorType),
-    createArgSuffixType('geoPositionLatLng', geoCoordinatesType, scalarType, scalarType),
+    createArgSuffixType(
+      'geoPositionLatLng',
+      geoCoordinatesType,
+      scalarType,
+      scalarType,
+    ),
+  );
+
+  addOperators(
+    bodyTargetType,
+    {
+      operator: OperatorKind.equal,
+      other: bodyTargetType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.notEqual,
+      other: bodyTargetType,
+      returnType: booleanType,
+    },
   );
 
   addPrototype(vesselTargetType, orbitableType);
   addSuffixes(
     vesselTargetType,
-    createArgSuffixType('partsNamed', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partsNamedPattern', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partsTitled', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partsTitledPattern', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partsDubbed', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partsDubbedPattern', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('modulesNamed', listType.toConcreteType(partModuleType), stringType),
-    createArgSuffixType('partsInGroup', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('modulesInGroup', listType.toConcreteType(partModuleType), stringType),
-    createArgSuffixType('partStagged', listType.toConcreteType(partType), stringType),
-    createArgSuffixType('partStaggedPattern', listType.toConcreteType(partType), stringType),
+    createArgSuffixType(
+      'partsNamed',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsNamedPattern',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsTitled',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsTitledPattern',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsDubbed',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsDubbedPattern',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'modulesNamed',
+      listType.toConcreteType(partModuleType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partsInGroup',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'modulesInGroup',
+      listType.toConcreteType(partModuleType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partStagged',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
+    createArgSuffixType(
+      'partStaggedPattern',
+      listType.toConcreteType(partType),
+      stringType,
+    ),
     createArgSuffixType('allTaggedParts', listType.toConcreteType(partType)),
     createArgSuffixType('parts', listType.toConcreteType(partType)),
-    createArgSuffixType('dockingPorts', listType.toConcreteType(dockingPortType)),
+    createArgSuffixType(
+      'dockingPorts',
+      listType.toConcreteType(dockingPortType),
+    ),
     createArgSuffixType('decouplers', listType.toConcreteType(decouplerType)),
     createArgSuffixType('separators', listType.toConcreteType(decouplerType)),
     createArgSuffixType('elements', userListType),
@@ -136,7 +206,10 @@ export const orbitalInitializer = () => {
     createSuffixType('controlPart', partType),
     createSuffixType('dryMass', scalarType),
     createSuffixType('wetMass', scalarType),
-    createSuffixType('resources', listType.toConcreteType(aggregateResourceType)),
+    createSuffixType(
+      'resources',
+      listType.toConcreteType(aggregateResourceType),
+    ),
     createSuffixType('loadDistance', loadDistanceType),
     createArgSuffixType('isDead', booleanType),
     createSuffixType('status', stringType),
@@ -148,6 +221,23 @@ export const orbitalInitializer = () => {
     createSuffixType('connection', vesselConnectionType),
     createSuffixType('messages', messageQueueType),
     createArgSuffixType('startTracking', voidType),
-    createArgSuffixType('soiChangeWatchers', uniqueSetType.toConcreteType(userDelegateType)),
+    createArgSuffixType(
+      'soiChangeWatchers',
+      uniqueSetType.toConcreteType(userDelegateType),
+    ),
+  );
+
+  addOperators(
+    vesselTargetType,
+    {
+      operator: OperatorKind.equal,
+      other: vesselTargetType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.notEqual,
+      other: vesselTargetType,
+      returnType: booleanType,
+    },
   );
 };

--- a/server/src/typeChecker/types/parts/part.ts
+++ b/server/src/typeChecker/types/parts/part.ts
@@ -5,7 +5,7 @@ import {
   createSuffixType,
   createSetSuffixType,
 } from '../../typeCreators';
-import { addPrototype, addSuffixes } from '../../typeUitlities';
+import { addPrototype, addSuffixes, addOperators } from '../../typeUitlities';
 import { structureType } from '../primitives/structure';
 import { directionType } from '../direction';
 import { vectorType } from '../collections/vector';
@@ -17,6 +17,7 @@ import { booleanType } from '../primitives/boolean';
 import { partModuleType } from './partModule';
 import { vesselTargetType } from '../orbital/vesselTarget';
 import { resourceType } from './resource';
+import { OperatorKind } from '../../types';
 
 export const partType: ArgumentType = createStructureType('part');
 addPrototype(partType, structureType);
@@ -52,4 +53,18 @@ addSuffixes(
   createSuffixType('mass', scalarType),
   createSuffixType('wetMass', scalarType),
   createSuffixType('hasPhysics', booleanType),
+);
+
+addOperators(
+  partType,
+  {
+    operator: OperatorKind.equal,
+    other: partType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.notEqual,
+    other: partType,
+    returnType: booleanType,
+  },
 );

--- a/server/src/typeChecker/types/primitives/initialize.ts
+++ b/server/src/typeChecker/types/primitives/initialize.ts
@@ -222,11 +222,6 @@ export const primitiveInitializer = () => {
       other: booleanType,
       returnType: booleanType,
     },
-    {
-      operator: OperatorKind.not,
-      returnType: booleanType,
-      other: undefined,
-    },
   );
   addPrototype(booleanType, primitiveType);
 };

--- a/server/src/typeChecker/types/primitives/initialize.ts
+++ b/server/src/typeChecker/types/primitives/initialize.ts
@@ -1,6 +1,10 @@
 import { addSuffixes, addPrototype, addOperators } from '../../typeUitlities';
 import { structureType } from './structure';
-import { createArgSuffixType, createVarSuffixType, createVarType } from '../../typeCreators';
+import {
+  createArgSuffixType,
+  createVarSuffixType,
+  createVarType,
+} from '../../typeCreators';
 import { stringType } from './string';
 import { booleanType } from './boolean';
 import { voidType } from './void';
@@ -10,6 +14,8 @@ import { scalarType, integerType, doubleType } from './scalar';
 import { listType } from '../collections/list';
 import { delegateType } from './delegate';
 import { OperatorKind } from '../../types';
+import { iterator } from '../../../utilities/constants';
+import { enumeratorType } from '../collections/enumerator';
 
 let set = false;
 
@@ -40,13 +46,41 @@ export const primitiveInitializer = () => {
   // ------------------ string ---------------------------
   addOperators(
     stringType,
-    [OperatorKind.plus, stringType],
-    [OperatorKind.greaterThan, booleanType],
-    [OperatorKind.lessThan, booleanType],
-    [OperatorKind.greaterThanEqual, booleanType],
-    [OperatorKind.lessThanEqual, booleanType],
-    [OperatorKind.equal, booleanType],
-    [OperatorKind.notEqual, booleanType],
+    {
+      operator: OperatorKind.plus,
+      other: structureType,
+      returnType: stringType,
+    },
+    {
+      operator: OperatorKind.greaterThan,
+      other: stringType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.lessThan,
+      other: stringType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.greaterThanEqual,
+      other: stringType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.lessThanEqual,
+      other: stringType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.equal,
+      other: stringType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.notEqual,
+      other: stringType,
+      returnType: booleanType,
+    },
   );
   addPrototype(stringType, primitiveType);
   addSuffixes(
@@ -62,7 +96,11 @@ export const primitiveInitializer = () => {
     createArgSuffixType('padright', stringType, scalarType),
     createArgSuffixType('remove', stringType, scalarType, scalarType),
     createArgSuffixType('replace', stringType, stringType, stringType),
-    createArgSuffixType('split', listType.toConcreteType(stringType), stringType),
+    createArgSuffixType(
+      'split',
+      listType.toConcreteType(stringType),
+      stringType,
+    ),
     createArgSuffixType('startswith', booleanType, stringType),
     createArgSuffixType('tolower', stringType),
     createArgSuffixType('toupper', stringType),
@@ -73,26 +111,80 @@ export const primitiveInitializer = () => {
     createArgSuffixType('tonumber', scalarType, structureType),
     createArgSuffixType('toscalar', scalarType, structureType),
     createArgSuffixType('format', stringType, structureType),
+    createArgSuffixType('indexof', stringType, structureType),
+    createArgSuffixType('find', stringType, structureType),
+    createArgSuffixType('lastindexof', scalarType, stringType),
+    createArgSuffixType('findlast', scalarType, stringType),
+    createArgSuffixType(iterator, enumeratorType.toConcreteType(stringType)),
   );
 
   // ------------------ scalar ---------------------------
   addOperators(
     scalarType,
-    [OperatorKind.plus, scalarType],
-    [OperatorKind.subtract, scalarType],
-    [OperatorKind.multiply, scalarType],
-    [OperatorKind.divide, scalarType],
-    [OperatorKind.power, scalarType],
-    [OperatorKind.greaterThan, booleanType],
-    [OperatorKind.lessThan, booleanType],
-    [OperatorKind.greaterThanEqual, booleanType],
-    [OperatorKind.lessThanEqual, booleanType],
-    [OperatorKind.notEqual, booleanType],
-    [OperatorKind.equal, booleanType],
+    {
+      operator: OperatorKind.plus,
+      other: scalarType,
+      returnType: scalarType,
+    },
+    {
+      operator: OperatorKind.subtract,
+      other: scalarType,
+      returnType: scalarType,
+    },
+    {
+      operator: OperatorKind.multiply,
+      other: scalarType,
+      returnType: scalarType,
+    },
+    {
+      operator: OperatorKind.divide,
+      other: scalarType,
+      returnType: scalarType,
+    },
+    {
+      operator: OperatorKind.power,
+      other: scalarType,
+      returnType: scalarType,
+    },
+    {
+      operator: OperatorKind.greaterThan,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.lessThan,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.greaterThanEqual,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.lessThanEqual,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.notEqual,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.equal,
+      other: scalarType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.negate,
+      returnType: scalarType,
+      other: undefined,
+    },
   );
   addPrototype(scalarType, primitiveType);
 
-  // ------------------ integar ---------------------------
+  // ------------------ integer ---------------------------
   addPrototype(integerType, scalarType);
 
   // ------------------ double ---------------------------
@@ -110,8 +202,31 @@ export const primitiveInitializer = () => {
   // ------------------ boolean ---------------------------
   addOperators(
     booleanType,
-    [OperatorKind.notEqual, booleanType],
-    [OperatorKind.equal, booleanType],
+    {
+      operator: OperatorKind.notEqual,
+      other: booleanType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.equal,
+      other: booleanType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.and,
+      other: booleanType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.or,
+      other: booleanType,
+      returnType: booleanType,
+    },
+    {
+      operator: OperatorKind.not,
+      returnType: booleanType,
+      other: undefined,
+    },
   );
   addPrototype(booleanType, primitiveType);
 };

--- a/server/src/typeChecker/types/timespan.ts
+++ b/server/src/typeChecker/types/timespan.ts
@@ -1,9 +1,11 @@
 import { ArgumentType } from './types';
-import { createStructureType, createSuffixType } from "../typeCreators";
-import { addPrototype, addSuffixes } from '../typeUitlities';
+import { createStructureType, createSuffixType } from '../typeCreators';
+import { addPrototype, addSuffixes, addOperators } from '../typeUitlities';
 import { scalarType } from './primitives/scalar';
 import { stringType } from './primitives/string';
 import { serializableStructureType } from './primitives/serializeableStructure';
+import { OperatorKind } from '../types';
+import { booleanType } from './primitives/boolean';
 
 export const timeSpanType: ArgumentType = createStructureType('timeSpan');
 addPrototype(timeSpanType, serializableStructureType);
@@ -18,4 +20,103 @@ addSuffixes(
   createSuffixType('seconds', scalarType),
   createSuffixType('clock', stringType),
   createSuffixType('calendar', stringType),
+);
+
+addOperators(
+  timeSpanType,
+  // +
+  {
+    operator: OperatorKind.plus,
+    other: timeSpanType,
+    returnType: timeSpanType,
+  },
+  {
+    operator: OperatorKind.plus,
+    other: scalarType,
+    returnType: timeSpanType,
+  },
+  // -
+  {
+    operator: OperatorKind.subtract,
+    other: timeSpanType,
+    returnType: timeSpanType,
+  },
+  {
+    operator: OperatorKind.subtract,
+    other: scalarType,
+    returnType: timeSpanType,
+  },
+  // *
+  {
+    operator: OperatorKind.multiply,
+    other: scalarType,
+    returnType: timeSpanType,
+  },
+  // /
+  {
+    operator: OperatorKind.divide,
+    other: timeSpanType,
+    returnType: timeSpanType,
+  },
+  {
+    operator: OperatorKind.divide,
+    other: scalarType,
+    returnType: timeSpanType,
+  },
+  // <
+  {
+    operator: OperatorKind.greaterThan,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.greaterThan,
+    other: scalarType,
+    returnType: booleanType,
+  },
+  // >
+  {
+    operator: OperatorKind.lessThan,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.lessThan,
+    other: scalarType,
+    returnType: booleanType,
+  },
+  // >=
+  {
+    operator: OperatorKind.greaterThanEqual,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.greaterThanEqual,
+    other: scalarType,
+    returnType: booleanType,
+  },
+  // <=
+  {
+    operator: OperatorKind.lessThanEqual,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
+  {
+    operator: OperatorKind.lessThanEqual,
+    other: scalarType,
+    returnType: booleanType,
+  },
+  // <>
+  {
+    operator: OperatorKind.notEqual,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
+  // =
+  {
+    operator: OperatorKind.equal,
+    other: timeSpanType,
+    returnType: booleanType,
+  },
 );

--- a/server/src/typeChecker/types/types.ts
+++ b/server/src/typeChecker/types/types.ts
@@ -1,5 +1,6 @@
 import { SuffixTracker } from '../../analysis/suffixTracker';
 import { CallKind, TypeKind, OperatorKind } from '../types';
+import { Operator } from '../operator';
 
 interface ITypeMeta<T> {
   toTypeString(): string;
@@ -11,7 +12,7 @@ export interface ITemplateBasicType<TSuffixType, TConcreteType>
   extends ITypeMeta<TConcreteType> {
   name: string;
   suffixes: Map<string, TSuffixType>;
-  operators: Map<OperatorKind, TConcreteType>;
+  operators: Map<OperatorKind, Operator[]>;
   superType?: ITemplateBasicType<TSuffixType, TConcreteType>;
   fullType: boolean;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pr introduced better representing of kerboscript operator's. Specifically this now removes the assumption that for binary operators the other operand is of the same time. This is most notable in the following example. This address issue #75.

      local result is v(1, 1, 1) * 10.
