### PR TITLE
run from boot and go to definition on run statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 - **Boot Directory** The boot directory now correctly resolves to the base of volume0
+- **Run Statement Go to Definition** Run statements now support go to definition in addition to symbols. This will open the file that kos-language server has resolve your run statement to. If the file is found it will go to. If a file extension is omitted kos-language server will attempt to look for a file with the `.ks` extension.
 
 ## Bug Fixes
 - **Globals** Global variables better reflect kOS with the following more actually being represented.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently the vscode client 0.9.0 implements the follow features
 - brace detection
 - code snippets
 - diagnostics on parsing errors
-- go to definition
+- go to definition and symbols and run statements
 - symbol auto complete
 - suffix auto complete
 - rename symbol

--- a/clients/vscode/README.md
+++ b/clients/vscode/README.md
@@ -1,3 +1,7 @@
 # KOS (Kerboscript) Vscode Client
 
-This is the kos-language-server client for visual studio code. Currently the extension itself provides next to nothing other than syntax highlighting and client support for the language server it's attached to.
+This is the kos-language-server client for visual studio code. 
+
+In addition to the features provided by the kos-language server this extension adds:
+- Syntax Highlighting
+- Commands to start KSP or your local telnet client

--- a/server/README.md
+++ b/server/README.md
@@ -22,7 +22,7 @@ the server can then be started by
 
 
 ## Features
-Currently the kos-language-server 0.8.2 implements the follow features
+Currently the kos-language-server 0.9.0 implements the follow features
 - Code completion
     - Built in symbols and keywords
     - local in scope symbols
@@ -38,7 +38,7 @@ Currently the kos-language-server 0.8.2 implements the follow features
     - potentially undefined symbols
     - symbols that are shadowed by other symbols
     - potentially unused symbols
-- Go to definition for each symbol in the open documents. In some case can resolve functions in other scripts that have been run.
+- Go to definition for symbols and run statements. Currently for clashing globals the first found will be shown
 - Refactoring
   - Rename symbol
 - On hover with experimental type inference support

--- a/server/src/kls.ts
+++ b/server/src/kls.ts
@@ -722,22 +722,35 @@ export class KLS {
     // check if symbols exists
     const { token, node } = result;
     if (empty(token.tracker)) {
+      // if no tracker it might be a run statment
       if (
         node instanceof Stmt.Run ||
         node instanceof Stmt.RunPath ||
         node instanceof Stmt.RunOncePath
       ) {
         const pathResolver = new PathResolver(this.configuration.workspaceUri);
+
+        // get the kos run path
         const kosPath = runPath(node);
         if (typeof kosPath !== 'string') {
           return undefined;
         }
 
+        // resolve to the file system
         const path = pathResolver.resolveUri(node.toLocation(uri), kosPath);
         if (empty(path)) {
           return undefined;
         }
 
+        // check if file exists then
+        if (existsSync(path.fsPath)) {
+          return Location.create(
+            path.toString(),
+            Range.create(Position.create(0, 0), Position.create(0, 0)),
+          );
+        }
+
+        // if we didn't find try to normalize the path with extension .ks
         const result = normalizeExtensions(path);
         if (empty(result)) {
           return undefined;

--- a/server/src/kls.ts
+++ b/server/src/kls.ts
@@ -67,6 +67,12 @@ import { TypeKind } from './typeChecker/types';
 import { DocumentLoader, Document } from './utilities/documentLoader';
 import { FoldableService } from './services/foldableService';
 import { AnalysisService } from './services/analysisService';
+import {
+  PathResolver,
+  runPath,
+  normalizeExtensions,
+} from './utilities/pathResolver';
+import { existsSync } from 'fs';
 
 export class KLS {
   /**
@@ -701,19 +707,57 @@ export class KLS {
     // try to find an symbol at the position
     const { script } = documentInfo;
     const finder = new ScriptFind();
-    const result = finder.find(script, pos);
+    const result = finder.find(
+      script,
+      pos,
+      Stmt.Run,
+      Stmt.RunPath,
+      Stmt.RunOncePath,
+    );
 
     if (empty(result)) {
       return undefined;
     }
 
     // check if symbols exists
-    const { tracker } = result.token;
-    if (empty(tracker)) {
+    const { token, node } = result;
+    if (empty(token.tracker)) {
+      if (
+        node instanceof Stmt.Run ||
+        node instanceof Stmt.RunPath ||
+        node instanceof Stmt.RunOncePath
+      ) {
+        const pathResolver = new PathResolver(this.configuration.workspaceUri);
+        const kosPath = runPath(node);
+        if (typeof kosPath !== 'string') {
+          return undefined;
+        }
+
+        const path = pathResolver.resolveUri(node.toLocation(uri), kosPath);
+        if (empty(path)) {
+          return undefined;
+        }
+
+        const result = normalizeExtensions(path);
+        if (empty(result)) {
+          return undefined;
+        }
+
+        const normalized = URI.parse(result);
+        if (!existsSync(normalized.fsPath)) {
+          return undefined;
+        }
+
+        return Location.create(
+          normalized.toString(),
+          Range.create(Position.create(0, 0), Position.create(0, 0)),
+        );
+      }
+
       return undefined;
     }
 
-    const { declared } = tracker;
+    const { declared } = token.tracker;
 
     // exit if undefined
     if (declared.uri === builtIn) {

--- a/server/src/services/documentService.ts
+++ b/server/src/services/documentService.ts
@@ -8,9 +8,8 @@ import {
   Range,
 } from 'vscode-languageserver';
 import { empty } from '../utilities/typeGuards';
-import { PathResolver } from '../utilities/pathResolver';
+import { PathResolver, normalizeExtensions } from '../utilities/pathResolver';
 import { URI } from 'vscode-uri';
-import { extname } from 'path';
 import { createDiagnostic } from '../utilities/diagnosticsUtils';
 import { DocumentLoader, Document } from '../utilities/documentLoader';
 import { logException, mockTracer } from '../utilities/logger';
@@ -107,7 +106,7 @@ export class DocumentService {
    * @param uri uri to lookup document
    */
   public getDocument(uri: string): Maybe<TextDocument> {
-    const normalized = this.normalizeExtensions(uri);
+    const normalized = normalizeExtensions(uri);
 
     if (empty(normalized)) {
       return undefined;
@@ -143,7 +142,7 @@ export class DocumentService {
     }
 
     // attempt to load a resource from whatever uri is provided
-    const normalized = this.normalizeExtensions(uri);
+    const normalized = normalizeExtensions(uri);
     if (empty(normalized)) {
       return this.loadError(caller.range, kosPath);
     }
@@ -180,7 +179,7 @@ export class DocumentService {
     }
 
     // attempt to load a resource from whatever uri is provided
-    const normalized = this.normalizeExtensions(uri);
+    const normalized = normalizeExtensions(uri);
     if (empty(normalized)) {
       return undefined;
     }
@@ -260,26 +259,6 @@ export class DocumentService {
       `Unable to load script at ${path}`,
       DiagnosticSeverity.Information,
     );
-  }
-
-  /**
-   * Normalize a filepath to the the default extension .ks if rules allow it to
-   * @param uri absolute resolved path
-   */
-  private normalizeExtensions(uri: URI | string): Maybe<string> {
-    const ext = URI.isUri(uri) ? extname(uri.fsPath) : extname(uri);
-    const uriString = uri.toString();
-
-    switch (ext) {
-      case '.ks':
-        return uriString;
-      case '.ksm':
-        return uriString.replace('.ksm', '.ks');
-      case '':
-        return `${uriString}.ks`;
-      default:
-        return undefined;
-    }
   }
 
   /**

--- a/server/src/tests/resolver.spec.ts
+++ b/server/src/tests/resolver.spec.ts
@@ -62,7 +62,9 @@ const resolveSource = (
   const symbolTableBuilder = new SymbolTableBuilder(fakeUri);
 
   if (standardLib) {
-    symbolTableBuilder.linkDependency(standardLibraryBuilder(CaseKind.lowercase));
+    symbolTableBuilder.linkDependency(
+      standardLibraryBuilder(CaseKind.lowercase),
+    );
   }
 
   const functionResolver = new PreResolver(
@@ -281,7 +283,7 @@ describe('Resolver tracking', () => {
     );
 
     // check test function
-    expect(testTracker).not.toBeUndefined();
+    expect(testTracker).toBeDefined();
     if (testTracker !== undefined) {
       const { name, tag } = testTracker.declared.symbol;
       expect(name.lexeme).toBe('test');
@@ -301,7 +303,7 @@ describe('Resolver tracking', () => {
     outOfScope = table.scopedNamedTracker(Position.create(0, 0), 'a');
 
     expect(outOfScope).toBeUndefined();
-    expect(aParamTracker).not.toBeUndefined();
+    expect(aParamTracker).toBeDefined();
     if (aParamTracker !== undefined) {
       const { name, tag } = aParamTracker.declared.symbol;
       expect(name.lexeme).toBe('a');
@@ -321,7 +323,7 @@ describe('Resolver tracking', () => {
     outOfScope = table.scopedNamedTracker(Position.create(0, 0), 'b');
 
     expect(outOfScope).toBeUndefined();
-    expect(bParamTracker).not.toBeUndefined();
+    expect(bParamTracker).toBeDefined();
     if (bParamTracker !== undefined) {
       const { name, tag } = bParamTracker.declared.symbol;
       expect(name.lexeme).toBe('b');
@@ -338,7 +340,7 @@ describe('Resolver tracking', () => {
     outOfScope = table.scopedNamedTracker(Position.create(6, 0), 'i');
 
     expect(outOfScope).toBeUndefined();
-    expect(iTracker).not.toBeUndefined();
+    expect(iTracker).toBeDefined();
     if (iTracker !== undefined) {
       const { name, tag } = iTracker.declared.symbol;
       expect(name.lexeme).toBe('i');
@@ -355,7 +357,7 @@ describe('Resolver tracking', () => {
     outOfScope = table.scopedNamedTracker(Position.create(15, 0), 'x');
 
     expect(outOfScope).toBeUndefined();
-    expect(xTracker).not.toBeUndefined();
+    expect(xTracker).toBeDefined();
     if (xTracker !== undefined) {
       const { name, tag } = xTracker.declared.symbol;
       expect(name.lexeme).toBe('x');
@@ -370,7 +372,7 @@ describe('Resolver tracking', () => {
     // check t lock
     const tTracker = table.scopedNamedTracker({ line: 16, character: 0 }, 't');
 
-    expect(tTracker).not.toBeUndefined();
+    expect(tTracker).toBeDefined();
     if (tTracker !== undefined) {
       const { name, tag } = tTracker.declared.symbol;
       expect(name.lexeme).toBe('t');
@@ -418,7 +420,7 @@ describe('Resolver tracking', () => {
     );
 
     // check test function
-    expect(shipTracker).not.toBeUndefined();
+    expect(shipTracker).toBeDefined();
     if (shipTracker !== undefined) {
       const { name, tag } = shipTracker.declared.symbol;
       expect(name.lexeme).toBe('ship');
@@ -434,7 +436,7 @@ describe('Resolver tracking', () => {
     );
 
     // check test function
-    expect(bodyTracker).not.toBeUndefined();
+    expect(bodyTracker).toBeDefined();
     if (bodyTracker !== undefined) {
       const { name, tag } = bodyTracker.declared.symbol;
       expect(name.lexeme).toBe('body');
@@ -450,7 +452,7 @@ describe('Resolver tracking', () => {
     );
 
     // check test function
-    expect(funcTracker).not.toBeUndefined();
+    expect(funcTracker).toBeDefined();
     if (funcTracker !== undefined) {
       const { name, tag } = funcTracker.declared.symbol;
       expect(name.lexeme).toBe('func');
@@ -466,7 +468,7 @@ describe('Resolver tracking', () => {
     );
 
     // check test function
-    expect(otherTracker).not.toBeUndefined();
+    expect(otherTracker).toBeDefined();
     if (otherTracker !== undefined) {
       const { name, tag } = otherTracker.declared.symbol;
       expect(name.lexeme).toBe('other');
@@ -778,7 +780,7 @@ describe('Function Scan', () => {
 
     if (funcStmt instanceof Decl.Func) {
       const scanResult = funcScanner.scan(funcStmt.block);
-      expect(scanResult).not.toBeUndefined();
+      expect(scanResult).toBeDefined();
 
       if (!empty(scanResult)) {
         expect(scanResult.return).toBe(false);
@@ -802,7 +804,7 @@ describe('Function Scan', () => {
 
     if (funcStmt instanceof Decl.Func) {
       const scanResult = funcScanner.scan(funcStmt.block);
-      expect(scanResult).not.toBeUndefined();
+      expect(scanResult).toBeDefined();
 
       if (!empty(scanResult)) {
         expect(scanResult.return).toBe(true);
@@ -826,7 +828,7 @@ describe('Function Scan', () => {
 
     if (funcStmt instanceof Decl.Func) {
       const scanResult = funcScanner.scan(funcStmt.block);
-      expect(scanResult).not.toBeUndefined();
+      expect(scanResult).toBeDefined();
 
       if (!empty(scanResult)) {
         expect(scanResult.return).toBe(true);
@@ -901,7 +903,7 @@ describe('Set Resolver', () => {
     const resolver = new SetResolver(local);
     if (stmt instanceof Stmt.Set) {
       const { used, set } = resolver.resolveExpr(stmt.suffix);
-      expect(set).not.toBeUndefined();
+      expect(set).toBeDefined();
       if (!empty(set)) {
         expect(set.lexeme).toBe('Thing');
       }

--- a/server/src/tests/service.spec.ts
+++ b/server/src/tests/service.spec.ts
@@ -118,7 +118,7 @@ describe('documentService', () => {
 
       for (let j = 0; j <= i; j += 1) {
         const doc = docService.getDocument(uris[j].toString());
-        expect(doc).not.toBeUndefined();
+        expect(doc).toBeDefined();
 
         if (!empty(doc)) {
           expect(doc.getText()).toBe(docs[j]);
@@ -182,7 +182,7 @@ describe('documentService', () => {
         `0:/${basename(uriString)}`,
       );
 
-      expect(loadedDoc).not.toBeUndefined();
+      expect(loadedDoc).toBeDefined();
       if (!empty(loadedDoc)) {
         expect(TextDocument.is(loadedDoc)).toBe(true);
         expect((loadedDoc as TextDocument).getText()).toBe(doc);
@@ -194,7 +194,7 @@ describe('documentService', () => {
 
       for (let j = 0; j <= i; j += 1) {
         const doc = docService.getDocument(uris[j].toString());
-        expect(doc).not.toBeUndefined();
+        expect(doc).toBeDefined();
 
         if (!empty(doc)) {
           expect(doc.getText()).toBe(docs[j]);
@@ -220,7 +220,7 @@ describe('documentService', () => {
         ),
         `0:/${basename(uriString)}`,
       );
-      expect(loadedDoc).not.toBeUndefined();
+      expect(loadedDoc).toBeDefined();
       expect(Diagnostic.is(loadedDoc)).toBe(true);
 
       if (Diagnostic.is(loadedDoc)) {
@@ -269,7 +269,7 @@ describe('documentService', () => {
 
       const loadedDoc = await docService.loadDocument(uriString);
 
-      expect(loadedDoc).not.toBeUndefined();
+      expect(loadedDoc).toBeDefined();
       if (!empty(loadedDoc)) {
         expect(TextDocument.is(loadedDoc)).toBe(true);
         expect((loadedDoc as TextDocument).getText()).toBe(doc);
@@ -281,7 +281,7 @@ describe('documentService', () => {
 
       for (let j = 0; j <= i; j += 1) {
         const doc = docService.getDocument(uris[j].toString());
-        expect(doc).not.toBeUndefined();
+        expect(doc).toBeDefined();
 
         if (!empty(doc)) {
           expect(doc.getText()).toBe(docs[j]);
@@ -353,7 +353,7 @@ describe('documentService', () => {
     expect(clientDocs.size).toBe(1);
 
     let clientDoc = docService.getDocument(uri.toString());
-    expect(clientDoc).not.toBeUndefined();
+    expect(clientDoc).toBeDefined();
     if (!empty(clientDoc)) {
       expect(clientDoc.getText()).toBe(content);
     }
@@ -373,7 +373,7 @@ describe('documentService', () => {
     expect(clientDocs.size).toBe(1);
 
     clientDoc = docService.getDocument(uri.toString());
-    expect(clientDoc).not.toBeUndefined();
+    expect(clientDoc).toBeDefined();
     if (!empty(clientDoc)) {
       expect(clientDoc.getText()).toBe(afterEdit);
     }
@@ -386,7 +386,7 @@ describe('documentService', () => {
     expect(clientDocs.size).toBe(0);
 
     clientDoc = docService.getDocument(uri.toString());
-    expect(clientDoc).not.toBeUndefined();
+    expect(clientDoc).toBeDefined();
     if (!empty(clientDoc)) {
       expect(clientDoc.getText()).toBe(afterEdit);
     }
@@ -439,7 +439,7 @@ describe('documentService', () => {
         `0:/${basename(uriString)}`,
       );
 
-      expect(loadedDoc).not.toBeUndefined();
+      expect(loadedDoc).toBeDefined();
       if (!empty(loadedDoc)) {
         expect(TextDocument.is(loadedDoc)).toBe(true);
         expect((loadedDoc as TextDocument).getText()).toBe(doc);
@@ -480,7 +480,7 @@ describe('analysisService', () => {
     const documentInfo = await analysisService.getInfo(uri);
 
     expect(diagnostics.length).toBe(0);
-    expect(documentInfo).not.toBeUndefined();
+    expect(documentInfo).toBeDefined();
 
     if (!empty(documentInfo)) {
       expect(documentInfo.symbolTable.dependencyTables.size).toBe(2);
@@ -512,7 +512,7 @@ describe('analysisService', () => {
 
     const documentInfo = await analysisService.getInfo(uri);
 
-    expect(documentInfo).not.toBeUndefined();
+    expect(documentInfo).toBeDefined();
 
     if (!empty(documentInfo)) {
       expect(documentInfo.symbolTable.dependencyTables.size).toBe(2);
@@ -618,8 +618,8 @@ describe('analysisService', () => {
     const documentInfo2 = await analysisService.getInfo(uri2);
 
     expect(diagnostics.length).toBe(0);
-    expect(documentInfo1).not.toBeUndefined();
-    expect(documentInfo2).not.toBeUndefined();
+    expect(documentInfo1).toBeDefined();
+    expect(documentInfo2).toBeDefined();
 
     if (!empty(documentInfo1) && !empty(documentInfo2)) {
       expect(documentInfo1.symbolTable.dependencyTables.size).toBe(3);
@@ -703,10 +703,10 @@ describe('analysisService', () => {
     expect(diagnostics21.length).toBe(0);
     expect(diagnostics22.length).toBe(0);
 
-    expect(documentInfo11).not.toBeUndefined();
-    expect(documentInfo12).not.toBeUndefined();
-    expect(documentInfo21).not.toBeUndefined();
-    expect(documentInfo22).not.toBeUndefined();
+    expect(documentInfo11).toBeDefined();
+    expect(documentInfo12).toBeDefined();
+    expect(documentInfo21).toBeDefined();
+    expect(documentInfo22).toBeDefined();
 
     const documentInfos = analysisService['documentInfos'];
 
@@ -728,7 +728,6 @@ describe('analysisService', () => {
     if (!empty(documentInfo12) && !empty(documentInfo22)) {
       expect(documentInfo12.symbolTable.dependencyTables.size).toBe(3);
       expect(documentInfo12.symbolTable.dependentTables.size).toBe(0);
-      console.log(documentInfo22);
       expect(documentInfo22.symbolTable.dependencyTables.size).toBe(2);
       expect(documentInfo22.symbolTable.dependentTables.size).toBe(1);
 

--- a/server/src/tests/symbols.spec.ts
+++ b/server/src/tests/symbols.spec.ts
@@ -66,11 +66,11 @@ describe('Symbol Table', () => {
     const uncleInfo = await analysisService.getInfo(uncleUri);
     const childInfo = await analysisService.getInfo(childUri);
 
-    expect(grandInfo).not.toBeUndefined();
-    expect(greatUncleInfo).not.toBeUndefined();
-    expect(parentInfo).not.toBeUndefined();
-    expect(uncleInfo).not.toBeUndefined();
-    expect(childInfo).not.toBeUndefined();
+    expect(grandInfo).toBeDefined();
+    expect(greatUncleInfo).toBeDefined();
+    expect(parentInfo).toBeDefined();
+    expect(uncleInfo).toBeDefined();
+    expect(childInfo).toBeDefined();
 
     if (
       !empty(grandInfo) &&
@@ -81,81 +81,59 @@ describe('Symbol Table', () => {
     ) {
       expect(
         grandInfo.symbolTable.globalEnvironment('grandparent'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         grandInfo.symbolTable.globalEnvironment('greatuncle'),
       ).toBeUndefined();
-      expect(
-        grandInfo.symbolTable.globalEnvironment('parent'),
-      ).not.toBeUndefined();
+      expect(grandInfo.symbolTable.globalEnvironment('parent')).toBeDefined();
       expect(grandInfo.symbolTable.globalEnvironment('uncle')).toBeUndefined();
-      expect(
-        grandInfo.symbolTable.globalEnvironment('child'),
-      ).not.toBeUndefined();
+      expect(grandInfo.symbolTable.globalEnvironment('child')).toBeDefined();
 
       expect(
         greatUncleInfo.symbolTable.globalEnvironment('grandparent'),
       ).toBeUndefined();
       expect(
         greatUncleInfo.symbolTable.globalEnvironment('greatuncle'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         greatUncleInfo.symbolTable.globalEnvironment('parent'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         greatUncleInfo.symbolTable.globalEnvironment('uncle'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         greatUncleInfo.symbolTable.globalEnvironment('child'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
 
       expect(
         parentInfo.symbolTable.globalEnvironment('grandparent'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         parentInfo.symbolTable.globalEnvironment('greatuncle'),
-      ).not.toBeUndefined();
-      expect(
-        parentInfo.symbolTable.globalEnvironment('parent'),
-      ).not.toBeUndefined();
-      expect(
-        parentInfo.symbolTable.globalEnvironment('uncle'),
-      ).not.toBeUndefined();
-      expect(
-        parentInfo.symbolTable.globalEnvironment('child'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
+      expect(parentInfo.symbolTable.globalEnvironment('parent')).toBeDefined();
+      expect(parentInfo.symbolTable.globalEnvironment('uncle')).toBeDefined();
+      expect(parentInfo.symbolTable.globalEnvironment('child')).toBeDefined();
 
       expect(
         uncleInfo.symbolTable.globalEnvironment('grandparent'),
       ).toBeUndefined();
       expect(
         uncleInfo.symbolTable.globalEnvironment('greatuncle'),
-      ).not.toBeUndefined();
-      expect(
-        uncleInfo.symbolTable.globalEnvironment('parent'),
-      ).not.toBeUndefined();
-      expect(
-        uncleInfo.symbolTable.globalEnvironment('uncle'),
-      ).not.toBeUndefined();
-      expect(
-        uncleInfo.symbolTable.globalEnvironment('child'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
+      expect(uncleInfo.symbolTable.globalEnvironment('parent')).toBeDefined();
+      expect(uncleInfo.symbolTable.globalEnvironment('uncle')).toBeDefined();
+      expect(uncleInfo.symbolTable.globalEnvironment('child')).toBeDefined();
 
       expect(
         childInfo.symbolTable.globalEnvironment('grandparent'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
       expect(
         childInfo.symbolTable.globalEnvironment('greatuncle'),
-      ).not.toBeUndefined();
-      expect(
-        childInfo.symbolTable.globalEnvironment('parent'),
-      ).not.toBeUndefined();
-      expect(
-        childInfo.symbolTable.globalEnvironment('uncle'),
-      ).not.toBeUndefined();
-      expect(
-        childInfo.symbolTable.globalEnvironment('child'),
-      ).not.toBeUndefined();
+      ).toBeDefined();
+      expect(childInfo.symbolTable.globalEnvironment('parent')).toBeDefined();
+      expect(childInfo.symbolTable.globalEnvironment('uncle')).toBeDefined();
+      expect(childInfo.symbolTable.globalEnvironment('child')).toBeDefined();
     }
   });
 });

--- a/server/src/tests/typeChecking.spec.ts
+++ b/server/src/tests/typeChecking.spec.ts
@@ -190,13 +190,13 @@ const symbolTests = (
   expect(symbols.has(name)).toBe(true);
   const nameWrap = symbols.get(name);
 
-  expect(nameWrap).not.toBeUndefined();
+  expect(nameWrap).toBeDefined();
   const nameUnWrap = unWrap(nameWrap);
 
   expect(nameUnWrap.name.lexeme).toBe(name);
   expect(nameUnWrap.tag).toBe(symbolKind);
 
-  expect(nameUnWrap.name.tracker).not.toBeUndefined();
+  expect(nameUnWrap.name.tracker).toBeDefined();
 
   if (!empty(targetType)) {
     const nameTrack = unWrap(nameUnWrap.name.tracker);

--- a/server/src/tests/utilitites.spec.ts
+++ b/server/src/tests/utilitites.spec.ts
@@ -101,6 +101,63 @@ describe('path resolver', () => {
       expect(weirdResolved.toString()).toBe(resolvedUri);
     }
   });
+
+  test('path resolver boot', () => {
+    const pathResolver = new PathResolver();
+    const range = {
+      start: {
+        line: 0,
+        character: 0,
+      },
+      end: {
+        line: 0,
+        character: 1,
+      },
+    };
+
+    const bootFileLocation: Location = {
+      range,
+      uri: 'file:///root/example/boot/otherFile.ks',
+    };
+
+    const relative1 = ['relative', 'path', 'file.ks'].join('/');
+    const absolute = ['0:', 'relative', 'path', 'file.ks'].join('/');
+    const weird = ['0:relative', 'path', 'file.ks'].join('/');
+
+    expect(
+      pathResolver.resolveUri(bootFileLocation, relative1),
+    ).toBeUndefined();
+    expect(pathResolver.resolveUri(bootFileLocation, absolute)).toBeUndefined();
+    expect(pathResolver.resolveUri(bootFileLocation, weird)).toBeUndefined();
+
+    pathResolver.volume0Uri = URI.file(join('root', 'example'));
+
+    const resolvedUri = 'file:///root/example/relative/path/file.ks';
+
+    const relativeResolved1 = pathResolver.resolveUri(
+      bootFileLocation,
+      relative1,
+    );
+    expect(relativeResolved1).toBeDefined();
+    if (!empty(relativeResolved1)) {
+      expect(relativeResolved1.toString()).toBe(resolvedUri);
+    }
+
+    const absoluteResolved = pathResolver.resolveUri(
+      bootFileLocation,
+      absolute,
+    );
+    expect(absoluteResolved).toBeDefined();
+    if (!empty(absoluteResolved)) {
+      expect(absoluteResolved.toString()).toBe(resolvedUri);
+    }
+
+    const weirdResolved = pathResolver.resolveUri(bootFileLocation, weird);
+    expect(weirdResolved).toBeDefined();
+    if (!empty(weirdResolved)) {
+      expect(weirdResolved.toString()).toBe(resolvedUri);
+    }
+  });
 });
 
 const createRange = (

--- a/server/src/utilities/pathResolver.ts
+++ b/server/src/utilities/pathResolver.ts
@@ -1,7 +1,7 @@
 import * as Stmt from '../parser/stmt';
 import * as SuffixTerm from '../parser/suffixTerm';
 import * as Expr from '../parser/expr';
-import { relative, join, dirname } from 'path';
+import { relative, join, dirname, extname } from 'path';
 import { RunStmtType } from '../parser/types';
 import { empty } from './typeGuards';
 import { TokenType } from '../entities/tokentypes';
@@ -74,6 +74,10 @@ export class PathResolver {
       return this.loadData(...remaining);
     }
 
+    if (relativePath === 'boot') {
+      return this.loadData(possibleVolume, ...remaining);
+    }
+
     // if no volume do a relative lookup
     return this.loadData(relativePath, possibleVolume, ...remaining);
   }
@@ -135,6 +139,26 @@ const literalPath = (expr: SuffixTerm.Literal): string | undefined => {
   }
 
   return undefined;
+};
+
+/**
+ * Normalize a filepath to the the default extension .ks if rules allow it to
+ * @param uri absolute resolved path
+ */
+export const normalizeExtensions = (uri: URI | string): Maybe<string> => {
+  const ext = URI.isUri(uri) ? extname(uri.fsPath) : extname(uri);
+  const uriString = uri.toString();
+
+  switch (ext) {
+    case '.ks':
+      return uriString;
+    case '.ksm':
+      return uriString.replace('.ksm', '.ks');
+    case '':
+      return `${uriString}.ks`;
+    default:
+      return undefined;
+  }
 };
 
 /**


### PR DESCRIPTION
This commit includes a bug fix for running from the boot drive. Now it correctly resolves files relative to volume 0. This commit also adds go to definition on run statements themselves