### PR TITLE
Type hinting

### DIFF
--- a/server/src/models/token.ts
+++ b/server/src/models/token.ts
@@ -14,6 +14,8 @@ export class Token implements TokenBase {
   public readonly end: Position;
   public readonly uri: string;
 
+  public ref: Maybe<Token>;
+  
   /**
    * What symbol tracker is this token tied too
    */
@@ -32,6 +34,7 @@ export class Token implements TokenBase {
     this.start = start;
     this.end = end;
     this.uri = uri;
+    this.ref = undefined;
     this.tracker = undefined;
   }
 
@@ -55,6 +58,10 @@ export class Token implements TokenBase {
       start: this.start,
       end: this.end,
     };
+  }
+
+  public get getRef(): Token | undefined {
+    return this.ref;
   }
 
   /**

--- a/server/src/models/tokentypes.ts
+++ b/server/src/models/tokentypes.ts
@@ -2,6 +2,7 @@ export enum TokenType {
     // whitespace
     whiteSpace, commentLine,
     region, endRegion,
+    type, returns,
 
     plus, minus, multi, div, power,
     not, and, or, true, false,

--- a/server/src/parser/models/declare.ts
+++ b/server/src/parser/models/declare.ts
@@ -1,5 +1,5 @@
 import { Stmt, Block } from './stmt';
-import { IExpr, IStmtVisitor, ScopeKind, NodeDataBuilder } from '../types';
+import { ITypeHint, IExpr, IStmtVisitor, ScopeKind, NodeDataBuilder } from '../types';
 import { TokenType } from '../../models/tokentypes';
 import { empty, unWrap } from '../../utilities/typeGuards';
 import { Range, Position } from 'vscode-languageserver';
@@ -103,6 +103,7 @@ export class Var extends Decl {
   public readonly toIs: Token;
   public readonly value: IExpr;
   public readonly scope: Scope;
+  public readonly typeHint?: ITypeHint;
 
   constructor(builder: NodeDataBuilder<Var>) {
     super();
@@ -110,6 +111,7 @@ export class Var extends Decl {
     this.toIs = unWrap(builder.toIs);
     this.value = unWrap(builder.value);
     this.scope = unWrap(builder.scope);
+    this.typeHint = builder.typeHint;
   }
 
   public toLines(): string[] {
@@ -148,6 +150,7 @@ export class Lock extends Decl {
   public readonly to: Token;
   public readonly value: IExpr;
   public readonly scope?: Scope;
+  public readonly typeHint?: ITypeHint;
 
   constructor(builder: NodeDataBuilder<Lock>) {
     super();
@@ -156,6 +159,7 @@ export class Lock extends Decl {
     this.to = unWrap(builder.to);
     this.value = unWrap(builder.value);
     this.scope = builder.scope;
+    this.typeHint = builder.typeHint;
   }
 
   public toLines(): string[] {
@@ -205,6 +209,7 @@ export class Func extends Decl {
   public readonly identifier: Token;
   public readonly block: Block;
   public readonly scope?: Scope;
+  public readonly typeHint?: ITypeHint;
 
   constructor(builder: NodeDataBuilder<Func>) {
     super();
@@ -212,6 +217,7 @@ export class Func extends Decl {
     this.identifier = unWrap(builder.identifier);
     this.block = unWrap(builder.block);
     this.scope = builder.scope;
+    this.typeHint = builder.typeHint;
   }
 
   public toLines(): string[] {
@@ -254,6 +260,7 @@ export class Param extends Decl {
   public readonly requiredParameters: Parameter[];
   public readonly optionalParameters: DefaultParam[];
   public readonly scope?: Scope;
+  public readonly typeHint?: ITypeHint;
 
   constructor(builder: NodeDataBuilder<Param>) {
     super();
@@ -261,6 +268,7 @@ export class Param extends Decl {
     this.requiredParameters = unWrap(builder.requiredParameters);
     this.optionalParameters = unWrap(builder.optionalParameters);
     this.scope = builder.scope;
+    this.typeHint = builder.typeHint;
   }
 
   public toLines(): string[] {
@@ -330,7 +338,10 @@ export class Param extends Decl {
 }
 
 export class Parameter extends NodeBase {
-  constructor(public readonly identifier: Token) {
+  constructor(
+    public readonly identifier: Token,
+    public readonly typeHint?: Maybe<string>,
+    ) {
     super();
   }
 
@@ -360,8 +371,9 @@ export class DefaultParam extends Parameter {
     identifier: Token,
     public readonly toIs: Token,
     public readonly value: IExpr,
+    typeHint?: Maybe<string>,
   ) {
-    super(identifier);
+    super(identifier, typeHint);
   }
 
   public toLines(): string[] {

--- a/server/src/parser/types.ts
+++ b/server/src/parser/types.ts
@@ -18,11 +18,16 @@ export interface IDeclScope extends RangeSequence {
   toString(): string;
 }
 
+export interface ITypeHint extends RangeSequence {
+  typeHint: string;
+  toString(): string;
+}
+
 export type NodeDataBuilder<T> = Partial<Writeable<NodeData<T>>>;
 
 export type NodeData<T> = Properties<
   T,
-  Token | NodeBase | NodeBase[] | undefined
+  Token | NodeBase | NodeBase[] | ITypeHint | undefined
 >;
 
 export type SuffixTermTrailer =
@@ -191,7 +196,8 @@ export type TreeNode =
   | IExpr
   | ISuffixTerm
   | IParameter
-  | IDeclScope;
+  | IDeclScope
+  | ITypeHint;
 
 export interface IExprVisitable {
   accept<T extends (...args: any) => any>(

--- a/server/src/scanner/types.ts
+++ b/server/src/scanner/types.ts
@@ -2,12 +2,13 @@ import { TokenType } from '../models/tokentypes';
 import { Diagnostic } from 'vscode-languageserver';
 import { Token } from '../models/token';
 
-export type ITokenMap = Map<string, { type: TokenType; literal?: any }>;
+export type ITokenMap = Map<string, { type: TokenType; literal?: any, ref?: Token }>;
 
 export interface Tokenized {
   tokens: Token[];
   scanDiagnostics: Diagnostic[];
   regions: Token[];
+  types: Token[];
 }
 
 export const enum ScanKind {
@@ -15,6 +16,7 @@ export const enum ScanKind {
   Token,
   Diagnostic,
   Region,
+  Type,
 }
 
 export type Result<T, S extends ScanKind> = {
@@ -26,9 +28,11 @@ export type TokenResult = Result<Token, ScanKind.Token>;
 export type WhitespaceResult = Result<null, ScanKind.Whitespace>;
 export type DiagnosticResult = Result<Diagnostic, ScanKind.Diagnostic>;
 export type RegionResult = Result<Token, ScanKind.Region>;
+export type TypeResult = Result<Token, ScanKind.Type>;
 
 export type ScanResult =
   | TokenResult
   | WhitespaceResult
   | DiagnosticResult
-  | RegionResult;
+  | RegionResult
+  | TypeResult;

--- a/server/src/services/analysisService.ts
+++ b/server/src/services/analysisService.ts
@@ -450,7 +450,7 @@ export class AnalysisService extends EventEmitter {
 
     performance.mark('scanner-start');
     const scanner = new Scanner(text, uri, this.logger, this.tracer);
-    const { tokens, scanDiagnostics, regions } = scanner.scanTokens();
+    const { tokens, scanDiagnostics, regions, types } = scanner.scanTokens();
     performance.mark('scanner-end');
 
     // if scanner found errors report those immediately
@@ -461,7 +461,7 @@ export class AnalysisService extends EventEmitter {
     }
 
     performance.mark('parser-start');
-    const parser = new Parser(uri, tokens, this.logger, this.tracer);
+    const parser = new Parser(uri, tokens, this.logger, this.tracer, types);
     const { script, parseDiagnostics } = parser.parse();
     performance.mark('parser-end');
 
@@ -606,6 +606,8 @@ export class AnalysisService extends EventEmitter {
     performance.mark('type-checking-start');
 
     const typeDiagnostics = typeChecker
+    // TODO: Kris: Get functions on first pass for set statements using functions
+    // .check(symbolTable)
       .check()
       .map(error => addDiagnosticsUri(error, uri));
 

--- a/server/src/typeChecker/ksTypes/typeHint.ts
+++ b/server/src/typeChecker/ksTypes/typeHint.ts
@@ -1,0 +1,160 @@
+
+/* import { queueType } from './collections/queue';
+import { listType } from './collections/list';
+import { stackType } from './collections/stack';
+import { uniqueSetType } from './collections/uniqueset'; */
+import { structureType } from './primitives/structure';
+import { nodeType } from './node';
+import { constantType } from './constant';
+import { pathType } from './io/path';
+import { volumeType } from './io/volume';
+import { vectorType } from './collections/vector';
+import { rgbaType } from './rgba';
+import { directionType } from './collections/direction';
+import { kacAlarmType } from './kacAlarmWrapper';
+import { geoCoordinatesType } from './geoCoordinates';
+import { bodyAtmosphereType } from './bodyatmosphere';
+import { noteType } from './note';
+import { voiceType } from './voice';
+import { hsvaType } from './hsva';
+import { vectorRendererType } from './vectorRenderer';
+import { guiWidgetType } from './gui/guiWidget';
+import { orbitableType } from './orbital/orbitable';
+import { timeSpanType } from './timespan';
+import { highlightType } from './highlight';
+import { orbitInfoType } from './orbitInfo';
+import { careerType } from './career';
+import { waypointType } from './waypoint';
+import { resourceTransferType } from './resourceTransfer';
+import { lexiconType } from './collections/lexicon';
+import { rangeType } from './collections/range';
+import { volumeFileType } from './io/volumneFile';
+import { pidLoopType } from './pidLoop';
+import { volumeItemType } from './io/volumeItem';
+import { volumeDirectoryType } from './io/volumeDirectory';
+import { delegateType } from './primitives/delegate';
+import { kUniverseType } from './kUniverse';
+import { homeConnectionType } from './communication/homeConnection';
+import { controlConnectionType } from './communication/controlConnection';
+import { vesselAltType } from './vessel/vesselAlt';
+import { vesselEtaType } from './vessel/vesselEta';
+import { stageType } from './vessel/stage';
+import { steeringManagerType } from './steeringManager';
+import { terminalStructType } from './terminalStruct';
+import { noneType } from './primitives/none';
+import { userListType } from './collections/userList';
+import {
+  scalarType,
+  doubleType,
+  integerType,
+} from './primitives/scalar';
+import { stringType } from './primitives/string';
+import { booleanType } from './primitives/boolean';
+import { coreType } from './core';
+import { versionInfoType } from './versionInfo';
+import { configType } from './config';
+import { builtInDelegateType } from './primitives/builtInDelegate';
+import { addonListType } from './addon/addonList';
+import { vesselSensorsType } from './vessel/vesselSensors';
+import { serializableType } from './primitives/serializeableStructure';
+import { bodyTargetType } from './orbital/bodyTarget';
+import { vesselTargetType } from './orbital/vesselTarget';
+import { boundsType } from './parts/bounds';
+import { IType } from '../types';
+import { Type } from '../models/types/type';
+import { partType } from './parts/part';
+import { kosProcessorFieldsType } from './kosProcessorFields';
+import { orbitableVelocityType } from './orbitalVelocity';
+import { aggregateResourceType } from './parts/aggregateResource';
+import { elementType } from './parts/element';
+import { engineType } from './parts/engine';
+import { dockingPortType } from './parts/dockingPort';
+import { scienceExperimentType } from './parts/scienceExperimentModule';
+import { scienceDataType } from './scienceData';
+import { listType } from './collections/list';
+import { partModuleType } from './parts/partModule';
+
+type ITypeMap = Map<string, IType|Type>;
+export const TypeHint: ITypeMap = new Map([
+//    ['', structureType],
+    ['aggregateResource', aggregateResourceType],
+    ['element', elementType],
+    ['kosProcessorFields', kosProcessorFieldsType],
+    ['vesselSensors', vesselSensorsType],
+    ['dockingPort', dockingPortType],
+    ['engine', engineType],
+    ['path', pathType],
+    ['structure', structureType],
+    ['node', nodeType],
+    ['none', noneType],
+    ['boolean', booleanType],
+    ['string', stringType],
+    ['scalar', scalarType],
+    ['integer', integerType],
+    ['double', doubleType],
+    ['delegate', delegateType],
+    ['bodyTarget', bodyTargetType],
+    ['volume', volumeType],
+    ['volumeItem', volumeItemType],
+    ['part', partType],
+    ['alt', vesselAltType],
+    ['addons', addonListType],
+    ['rgba', rgbaType],
+    ['config', configType],
+    ['constant', constantType],
+    ['control', controlConnectionType],
+    ['core', coreType],
+    ['orbitInfo', orbitInfoType],
+    ['eta', vesselEtaType],
+    ['facing', directionType],
+    ['direction', directionType],
+    ['geoposition', geoCoordinatesType],
+    ['homeconnection', homeConnectionType],
+    ['kuniverse', kUniverseType],
+    ['vesselTarget', vesselTargetType],
+    ['vector', vectorType],
+    ['stage', stageType],
+    ['steeringmanager', steeringManagerType],
+    ['terminal', terminalStructType],
+    ['time', timeSpanType],
+    ['velocity', orbitableType],
+    ['orbitable', orbitableType],
+    ['version', versionInfoType],
+    ['bounds', boundsType],
+    ['orbitableVelocity', orbitableVelocityType],
+    ['serializable', serializableType],
+    ['builtInDelegate', builtInDelegateType],
+    ['userList', userListType],
+    ['pidLoop', pidLoopType],
+    ['volumeDirectory', volumeDirectoryType],
+    ['resourceTransfer', resourceTransferType],
+    ['lexicon', lexiconType],
+    ['volumeFile', volumeFileType],
+    ['range', rangeType],
+    ['kacAlarm', kacAlarmType],
+    ['bodyAtmosphere', bodyAtmosphereType],
+    ['waypoint', waypointType],
+    ['career', careerType],
+    ['highlight', highlightType],
+    ['guiWidget', guiWidgetType],
+    ['vectorRenderer', vectorRendererType],
+    ['scienceData', scienceDataType],
+    ['partModule', partModuleType],
+    ['vesselList', listType.apply(vesselTargetType)],
+    ['partModuleList', listType.apply(partModuleType)],
+    ['shipParts', listType.apply(partType)],
+    ['partList', listType.apply(partType)],
+    ['scienceExperimentList', listType.apply(scienceExperimentType)],
+    ['scienceExperiment', scienceExperimentType],
+    ['voice', voiceType],
+    ['note', noteType],
+    ['hsva', hsvaType],
+    ['NULL', noneType],
+  ]);
+  
+/* const SpecialHint: [string[], IType][] = [
+    ['list', listType],
+    ['queue', queueType],
+    ['stack', stackType],
+    ['uniqueSet', uniqueSetType],
+  ]; */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
I made quite few changes like type hinting `// #type: vesselTarget` over the weekend.
PR adds typehinting with syntax `// #type: typestring` and `// #returns: typestring`

It also takes the parameters for functions to generate function signature.

There is some residue code from testing out:
Noticed that I had to do 2 passes over the whole code, because kos allows to have functions defined after calling them, but the code currently would give warning about signature not found. 

The code is not the prettiest and not the cleanest, but could be useful. 

* **What is the current behavior?** (You can also link to an open issue here)
No possibility of code hinting

* **What is the new behavior (if this is a feature change)?**
Possibility of code hinting

* **Problems/Limitation**:
Currently the limitation is that 1 parameter per line, if there are more, then it still takes first typestring and applies it to first parameter in the line.
There are some issues still. on function you can have `// #type: typestring` and `// #returns: typestring`. Both work the same. Needs way to differentiate between 2 of them.
Type-hinting at the moment only lets you to enter only one type. Not possible to make it something like `exist()` command has (**string** or **path**)
Probably should change the syntax to work more like `// #parametername: typestring` for parameters.

* **Other information**:
Some changes in suffixes and such that came out as problems when testing code. Probably another PR.