### PR TITLE
missed coverage folder move

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,4 @@ server/build/**
 server/out/**
 server/bin/**
 server/node_modules/**
+server/coverage/**

--- a/kerboscripts/parser_valid/ksconfig.json
+++ b/kerboscripts/parser_valid/ksconfig.json
@@ -1,7 +1,1 @@
-{
-  "archive": "string",
-  "bodies": ["Mun", "Kerbin", "Earth", "Duna", "Mon"],
-  "lintRules": {
-    "invalid-break": "error"
-  }
-}
+{}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This add a new vscodeignore entry for coverages as it has been moved up the folder structure. This reduces the extension size from ~1.2MB to 200Kb
