### PR TITLE
Fixes rename bug

### DIFF
--- a/server/src/analysis/resolver.ts
+++ b/server/src/analysis/resolver.ts
@@ -962,6 +962,15 @@ export class Resolver
     const errors = this.useExprLocalsBind(stmt.expr);
     errors.push(...this.resolveExpr(stmt.expr));
 
+    if (!empty(stmt.x) && !empty(stmt.y)) {
+      errors.push(...this.useExprLocals(stmt.x));
+      errors.push(...this.useExprLocals(stmt.y));
+
+      errors.push(...this.resolveExpr(stmt.x));
+      errors.push(...this.resolveExpr(stmt.y));
+
+    }
+
     return errors;
   }
 

--- a/server/src/kls.ts
+++ b/server/src/kls.ts
@@ -420,7 +420,7 @@ export class KLS {
       return undefined;
     }
 
-    const locations = await this.getUsageLocations(position, textDocument.uri);
+    const locations = await this.getSymbolLocations(position, textDocument.uri);
     if (empty(locations)) {
       return undefined;
     }
@@ -543,7 +543,7 @@ export class KLS {
       return undefined;
     }
 
-    const locations = await this.getUsageLocations(position, uri);
+    const locations = await this.getSymbolLocations(position, uri);
     return locations && locations.map(loc => cleanLocation(loc));
   }
 
@@ -944,7 +944,7 @@ export class KLS {
    * @param pos position in document
    * @param uri uri of document
    */
-  public async getUsageLocations(
+  public async getSymbolLocations(
     pos: Position,
     uri: string,
   ): Promise<Maybe<Location[]>> {
@@ -976,10 +976,9 @@ export class KLS {
       return undefined;
     }
 
-    return tracker.usages
-      .map(usage => usage as Location)
-      .concat(tracker.declared.symbol.name)
-      .filter(location => location.uri !== builtIn);
+    return [tracker.declared, ...tracker.usages, ...tracker.sets].filter(
+      location => location.uri !== builtIn,
+    );
   }
 
   /**
@@ -991,7 +990,7 @@ export class KLS {
     pos: Position,
     uri: string,
   ): Promise<Maybe<Range[]>> {
-    const locations = await this.getUsageLocations(pos, uri);
+    const locations = await this.getSymbolLocations(pos, uri);
     if (empty(locations)) {
       return locations;
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a bug in renaming where symbols on the lhs were not updated
- This also fixes a bug for show all references
- minor fix to `print expr at(x, y)`

