### PR TITLE
Fix function arity and type errors

### DIFF
--- a/server/src/typeChecker/ksTypes/primitives/none.ts
+++ b/server/src/typeChecker/ksTypes/primitives/none.ts
@@ -9,4 +9,5 @@ export const noneType = new Type(
   undefined,
   undefined,
   false,
+  true,
 );

--- a/server/src/typeChecker/models/parametricTypes/parametricCallSignature.ts
+++ b/server/src/typeChecker/models/parametricTypes/parametricCallSignature.ts
@@ -124,6 +124,20 @@ export class GenericCallSignature implements IParametricCallSignature {
   }
 
   /**
+   * The required number of parameters
+   */
+  public requiredParams(): number {
+    let count = 0;
+    for (const param of this.paramMaps?.values() ?? []) {
+      if (!param.type.noneType) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
+  /**
    * Call signature return
    */
   public returns() {

--- a/server/src/typeChecker/models/parametricTypes/parametricType.ts
+++ b/server/src/typeChecker/models/parametricTypes/parametricType.ts
@@ -38,6 +38,11 @@ export class ParametricType implements IParametricType {
   public readonly anyType: boolean;
 
   /**
+   * Is this the none type
+   */
+  public readonly noneType: boolean;
+
+  /**
    * What is the call signature of this type
    */
   protected typeCallSignature?: TypeMap<IParametricCallSignature>;
@@ -89,6 +94,7 @@ export class ParametricType implements IParametricType {
     this.access = access;
     this.kind = kind;
     this.anyType = false;
+    this.noneType = false;
     this.binder = new TypeBinder(typeParameters);
 
     this.superType = undefined;

--- a/server/src/typeChecker/models/types/callSignature.ts
+++ b/server/src/typeChecker/models/types/callSignature.ts
@@ -38,6 +38,17 @@ export class CallSignature implements ICallSignature {
     return this.paramTypes;
   }
 
+  public requiredParams(): number {
+    let count = 0;
+    for (const param of this.paramTypes) {
+      if (!param.noneType) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
   /**
    * Get the return of this call signature
    */

--- a/server/src/typeChecker/models/types/delegateType.ts
+++ b/server/src/typeChecker/models/types/delegateType.ts
@@ -33,6 +33,11 @@ export class DelegateType implements IType {
   public readonly anyType: boolean;
 
   /**
+   * Is this delegate the none type
+   */
+  public readonly noneType: boolean;
+
+  /**
    * What is the type of this delegate
    */
   public readonly kind: TypeKind;
@@ -59,6 +64,7 @@ export class DelegateType implements IType {
     this.function = type;
     this.access = { get: true, set: true };
     this.anyType = false;
+    this.noneType = false;
     this.name = 'delegate';
     this.typeTracker = new TypeTracker(new KsSuffix(this.name), this);
     this.kind = TypeKind.delegate;

--- a/server/src/typeChecker/models/types/type.ts
+++ b/server/src/typeChecker/models/types/type.ts
@@ -44,6 +44,11 @@ export class Type implements IType {
   public readonly anyType: boolean;
 
   /**
+   * Is this type the none type
+   */
+  public readonly noneType: boolean;
+
+  /**
    * The type arguments for this type if any
    */
   private readonly typeArguments: Map<IParametricType, IType>;
@@ -92,6 +97,7 @@ export class Type implements IType {
    * @param callSignature what is the call signature of this type
    * @param typeTemplate what is the type template of this type
    * @param anyType is this the any type
+   * @param noneType is this the none type
    */
   constructor(
     name: string,
@@ -101,6 +107,7 @@ export class Type implements IType {
     callSignature?: ICallSignature,
     typeTemplate?: IParametricType,
     anyType = false,
+    noneType = false,
   ) {
     if (kind === TypeKind.variadic) {
       throw new Error('Cannot construct variadic type.');
@@ -113,6 +120,7 @@ export class Type implements IType {
     this.typeCallSignature = callSignature;
     this.typeTemplate = typeTemplate;
     this.anyType = anyType;
+    this.noneType = noneType;
 
     // TODO will need to actually be robust about this
     this.typeTracker =

--- a/server/src/typeChecker/models/types/unionType.ts
+++ b/server/src/typeChecker/models/types/unionType.ts
@@ -34,6 +34,11 @@ export class UnionType implements IType {
   public readonly anyType: boolean;
 
   /**
+   * Is this union the none type
+   */
+  public readonly noneType: boolean;
+
+  /**
    * What is the type of this union
    */
   public readonly kind: TypeKind;
@@ -82,7 +87,8 @@ export class UnionType implements IType {
     this.param = isParameter;
     this.types = sortedTypes;
     this.name = 'Union';
-    this.anyType = sortedTypes.every(type => type.anyType);
+    this.anyType = sortedTypes.some(type => type.anyType);
+    this.noneType = sortedTypes.some(type => type.noneType);
     this.access = {
       get: sortedTypes.every(type => type.access.get),
       set: sortedTypes.every(type => type.access.set),

--- a/server/src/typeChecker/models/types/variadicType.ts
+++ b/server/src/typeChecker/models/types/variadicType.ts
@@ -12,6 +12,7 @@ import { TypeTracker } from '../../../analysis/models/typeTracker';
 
 export class VariadicType implements IType {
   public readonly anyType: boolean;
+  public readonly noneType: boolean;
   public readonly name: string;
   public readonly access: Access;
   public readonly kind: TypeKind;
@@ -23,6 +24,7 @@ export class VariadicType implements IType {
     this.access = { get: false, set: false };
     this.kind = TypeKind.variadic;
     this.anyType = false;
+    this.noneType = false;
   }
 
   public isSubtypeOf(type: IType): boolean {

--- a/server/src/typeChecker/types.ts
+++ b/server/src/typeChecker/types.ts
@@ -171,6 +171,11 @@ export interface IParametricType extends ITypeMappable<IType> {
   readonly anyType: boolean;
 
   /**
+   * Is this type the void type. i.e does it represent nothing
+   */
+  readonly noneType: boolean;
+
+  /**
    * What is the kind of this type
    */
   readonly kind: TypeKind;
@@ -352,6 +357,11 @@ export interface IParametricCallSignature
    * The types of the parameters
    */
   params(): IParametricType[];
+
+  /**
+   * The required number of parameters
+   */
+  requiredParams(): number;
 
   /**
    * The type of the return


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes several small issues with the type checking around function and suffix calls. Now we should be able to correctly identify arity and call arguments.

