### PR TITLE
Symbols now produces a hierarchy in vscode

### DIFF
--- a/server/src/analysis/models/symbolTableBuilder.ts
+++ b/server/src/analysis/models/symbolTableBuilder.ts
@@ -327,18 +327,19 @@ export class SymbolTableBuilder {
 
   /**
    * Add a new variable symbol to the table
-   * @param scopeType the requested scope type
+   * @param scopeKind the requested scope type
    * @param token token for the requested variable
    * @param type type to declare variable as
    */
   public declareVariable(
-    scopeType: ScopeKind,
+    scopeKind: ScopeKind,
     token: Token,
+    range: Range,
     type?: IType,
   ): Maybe<Diagnostic> {
     const conflictTracker = this.lookupKind(
       token.lookup,
-      scopeType,
+      scopeKind,
       KsSymbolKind.variable,
     );
 
@@ -350,7 +351,7 @@ export class SymbolTableBuilder {
     let diagnostic: Maybe<Diagnostic>;
 
     // if global we can't shadow
-    if (scopeType === ScopeKind.global) {
+    if (scopeKind === ScopeKind.global) {
       diagnostic = undefined;
 
       // if local check for shadowing hints
@@ -369,9 +370,9 @@ export class SymbolTableBuilder {
           );
     }
 
-    const scopeNode = this.selectScopeNode(scopeType);
+    const scopeNode = this.selectScopeNode(scopeKind);
     const tracker = new BasicTracker(
-      new KsVariable(scopeType, token),
+      new KsVariable(scopeKind, token, range),
       this.uri,
       type,
     );
@@ -388,7 +389,7 @@ export class SymbolTableBuilder {
 
   /**
    * Add a new function symbol to the table
-   * @param scopeType the requested scope type
+   * @param scopeKind the requested scope type
    * @param token token for the requested function
    * @param requiredParameters required parameters for the function
    * @param optionalParameters optional parameters for the function
@@ -396,8 +397,9 @@ export class SymbolTableBuilder {
    * @param type type to declare function as
    */
   public declareFunction(
-    scopeType: ScopeKind,
+    scopeKind: ScopeKind,
     token: Token,
+    range: Range,
     requiredParameters: number,
     optionalParameters: number,
     returnValue: boolean,
@@ -405,7 +407,7 @@ export class SymbolTableBuilder {
   ): Maybe<Diagnostic> {
     const conflictTracker = this.lookupKind(
       token.lookup,
-      scopeType,
+      scopeKind,
       KsSymbolKind.function,
     );
 
@@ -417,7 +419,7 @@ export class SymbolTableBuilder {
     let diagnostic: Maybe<Diagnostic>;
 
     // if global we can't shadow
-    if (scopeType === ScopeKind.global) {
+    if (scopeKind === ScopeKind.global) {
       diagnostic = undefined;
 
       // if local check for shadowing hints
@@ -436,11 +438,12 @@ export class SymbolTableBuilder {
           );
     }
 
-    const scopeNode = this.selectScopeNode(scopeType);
+    const scopeNode = this.selectScopeNode(scopeKind);
     const tracker = new BasicTracker(
       new KsFunction(
-        scopeType,
+        scopeKind,
         token,
+        range,
         requiredParameters,
         optionalParameters,
         returnValue,
@@ -461,18 +464,19 @@ export class SymbolTableBuilder {
 
   /**
    * Add a new lock symbol to the table
-   * @param scopeType the requested scope type
+   * @param scopeKind the requested scope type
    * @param token token for the requested lock
    * @param type type to declare lock as
    */
   public declareLock(
-    scopeType: ScopeKind,
+    scopeKind: ScopeKind,
     token: Token,
+    range: Range,
     type?: IType,
   ): Maybe<Diagnostic> {
     const conflictTracker = this.lookupKind(
       token.lookup,
-      scopeType,
+      scopeKind,
       KsSymbolKind.lock,
     );
 
@@ -484,7 +488,7 @@ export class SymbolTableBuilder {
     let diagnostic: Maybe<Diagnostic>;
 
     // if global we can't shadow
-    if (scopeType === ScopeKind.global) {
+    if (scopeKind === ScopeKind.global) {
       diagnostic = undefined;
 
       // if local check for shadowing hints
@@ -503,9 +507,9 @@ export class SymbolTableBuilder {
           );
     }
 
-    const scopeNode = this.selectScopeNode(scopeType);
+    const scopeNode = this.selectScopeNode(scopeKind);
     const tracker = new BasicTracker(
-      new KsLock(scopeType, token),
+      new KsLock(scopeKind, token, range),
       this.uri,
       type,
     );
@@ -522,18 +526,18 @@ export class SymbolTableBuilder {
 
   /**
    * Add a new parameter symbol to the table
-   * @param scopeType the requested scope type
+   * @param scopeKind the requested scope type
    * @param token token for the requested parameter
    * @param defaulted is the parameter defaulted
    */
   public declareParameter(
-    scopeType: ScopeKind,
+    scopeKind: ScopeKind,
     token: Token,
-    defaulted: boolean,
+    range: Range,
   ): Maybe<Diagnostic> {
     const conflictTracker = this.lookupKind(
       token.lookup,
-      scopeType,
+      scopeKind,
       KsSymbolKind.parameter,
     );
 
@@ -545,7 +549,7 @@ export class SymbolTableBuilder {
     let diagnostic: Maybe<Diagnostic>;
 
     // if global we can't shadow
-    if (scopeType === ScopeKind.global) {
+    if (scopeKind === ScopeKind.global) {
       diagnostic = undefined;
 
       // if local check for shadowing hints
@@ -564,9 +568,9 @@ export class SymbolTableBuilder {
           );
     }
 
-    const scopeNode = this.selectScopeNode(scopeType);
+    const scopeNode = this.selectScopeNode(scopeKind);
     const tracker = new BasicTracker(
-      new KsParameter(token, defaulted),
+      new KsParameter(token, range),
       this.uri,
     );
 

--- a/server/src/analysis/preResolver.ts
+++ b/server/src/analysis/preResolver.ts
@@ -181,6 +181,7 @@ export class PreResolver
     const declareErrors = this.tableBuilder.declareFunction(
       scopeType,
       decl.identifier,
+      decl,
       result.requiredParameters,
       result.optionalParameters,
       result.return,

--- a/server/src/analysis/standardLibrary.ts
+++ b/server/src/analysis/standardLibrary.ts
@@ -78,6 +78,7 @@ import { empty } from '../utilities/typeGuards';
 import { partType } from '../typeChecker/ksTypes/parts/part';
 import { kosProcessorFieldsType } from '../typeChecker/ksTypes/kosProcessorFields';
 import { orbitableVelocityType } from '../typeChecker/ksTypes/orbitalVelocity';
+import { Range } from 'vscode-languageserver';
 
 const functionTypes: [string[], IType][] = [
   [['abs'], createFunctionType('abs', scalarType, scalarType)],
@@ -768,7 +769,7 @@ const variables: [string[], IType][] = [
   [['terminal'], terminalStructType],
   [['time'], timeSpanType],
   [['up'], directionType],
-  [['velocity'], orbitableType],
+  [['velocity'], orbitableVelocityType],
   [['version'], versionInfoType],
   [['vertical', 'speed'], scalarType],
   [['volume:name'], stringType],
@@ -798,6 +799,7 @@ export const standardLibraryBuilder = (caseKind: CaseKind): SymbolTable => {
         new Marker(0, 0),
         builtIn,
       ),
+      Range.create(new Marker(0, 0), new Marker(0, 0)),
       parameterCount,
       0,
       false,
@@ -816,6 +818,7 @@ export const standardLibraryBuilder = (caseKind: CaseKind): SymbolTable => {
         new Marker(0, 0),
         builtIn,
       ),
+      Range.create(new Marker(0, 0), new Marker(0, 0)),
       type,
     );
   }
@@ -831,6 +834,7 @@ export const standardLibraryBuilder = (caseKind: CaseKind): SymbolTable => {
         new Marker(0, 0),
         builtIn,
       ),
+      Range.create(new Marker(0, 0), new Marker(0, 0)),
       type,
     );
   }
@@ -855,6 +859,7 @@ export const bodyLibraryBuilder = (
         new Marker(0, 0),
         builtIn,
       ),
+      Range.create(new Marker(0, 0), new Marker(0, 0)),
       bodyTargetType,
     );
   }

--- a/server/src/kls.ts
+++ b/server/src/kls.ts
@@ -31,7 +31,6 @@ import {
 import { ClientConfiguration, DiagnosticUri } from './types';
 import { Scanner } from './scanner/scanner';
 import {
-  KsSymbol,
   KsSymbolKind,
   SymbolTracker,
   KsBaseSymbol,
@@ -1034,7 +1033,7 @@ export class KLS {
    * Get all symbols in a provided file
    * @param uri document uri
    */
-  public async getAllFileSymbols(uri: string): Promise<KsSymbol[]> {
+  public async getAllFileSymbols(uri: string): Promise<KsBaseSymbol[]> {
     const documentInfo = await this.analysisService.getInfo(uri);
 
     if (empty(documentInfo)) {

--- a/server/src/models/function.ts
+++ b/server/src/models/function.ts
@@ -1,6 +1,7 @@
 import { ScopeKind } from '../parser/types';
 import { KsSymbolKind } from '../analysis/types';
 import { Token } from './token';
+import { Range } from 'vscode-languageserver';
 
 /**
  * A class containing the information of a function
@@ -10,6 +11,7 @@ export class KsFunction {
    * A kerboscript function constructor
    * @param scope the scope of this variable
    * @param name the name of this variable
+   * @param range the range of the function
    * @param requiredParameters the number of required parameters
    * @param optionalParameters the number of optional parameters
    * @param returnValue does the function return a value
@@ -17,6 +19,7 @@ export class KsFunction {
   constructor(
     public readonly scope: ScopeKind,
     public readonly name: Token,
+    public readonly range: Range,
     public readonly requiredParameters: number,
     public readonly optionalParameters: number,
     public readonly returnValue: boolean,

--- a/server/src/models/lock.ts
+++ b/server/src/models/lock.ts
@@ -1,6 +1,7 @@
 import { ScopeKind } from '../parser/types';
 import { KsSymbolKind } from '../analysis/types';
 import { Token } from './token';
+import { Range } from 'vscode-languageserver';
 
 /**
  * A class containing the information of a lock
@@ -10,10 +11,12 @@ export class KsLock {
    * A kerboscript lock constructor
    * @param scope the scope of this lock
    * @param name the name of this lock
+   * @param range the range of this lock
    */
   constructor(
     public readonly scope: ScopeKind,
     public readonly name: Token,
+    public readonly range: Range,
   )
   { }
 

--- a/server/src/models/parameter.ts
+++ b/server/src/models/parameter.ts
@@ -1,5 +1,6 @@
 import { KsSymbolKind } from '../analysis/types';
 import { Token } from './token';
+import { Range } from 'vscode-languageserver';
 
 /**
  * A class containing the information of a parameter
@@ -8,11 +9,11 @@ export class KsParameter {
   /**
    * A kerboscript parameter constructor
    * @param name the name of this parameter
-   * @param defaulted is this parameter defaulted
+   * @param range the range of this parameter
    */
   constructor(
     public readonly name: Token,
-    public readonly defaulted: boolean,
+    public readonly range: Range,
   )
   { }
 

--- a/server/src/models/variable.ts
+++ b/server/src/models/variable.ts
@@ -1,6 +1,7 @@
 import { ScopeKind } from '../parser/types';
 import { KsSymbolKind } from '../analysis/types';
 import { Token } from './token';
+import { Range } from 'vscode-languageserver';
 
 /**
  * A class containing the information of a variable
@@ -10,10 +11,12 @@ export class KsVariable {
    * A kerboscript variable constructor
    * @param scope the scope of this variable
    * @param name the name of this variable
+   * @param range the range of this variable
    */
   constructor(
     public readonly scope: ScopeKind,
     public readonly name: Token,
+    public readonly range: Range,
   )
   { }
 

--- a/server/src/utilities/serverUtils.ts
+++ b/server/src/utilities/serverUtils.ts
@@ -16,7 +16,7 @@ import {
   Position,
 } from 'vscode-languageserver';
 import { empty } from './typeGuards';
-import { KsSymbolKind, KsSymbol, KsBaseSymbol } from '../analysis/types';
+import { KsSymbolKind, KsBaseSymbol } from '../analysis/types';
 import { cleanLocation, cleanToken, cleanCompletion } from './clean';
 import { CommanderStatic } from 'commander';
 import { DiagnosticUri } from '../types';
@@ -299,22 +299,18 @@ const findContainingSuffixTermTrailer = (
  * @param documentSymbol document identifier
  */
 export const toDocumentSymbols = (
-  entities: KsSymbol[],
+  entities: KsBaseSymbol[],
   uri: string,
 ): Maybe<SymbolInformation[]> => {
   return entities.map(entity => {
     const kind: Maybe<SymbolKind> = symbolSymbolMapper(entity.tag);
-
-    if (typeof entity.name === 'string') {
-      throw new Error('Expected symbol tracker not type tracker');
-    }
 
     return {
       kind,
       name: entity.name.lexeme,
       location: cleanLocation({
         uri: entity.name.uri || uri,
-        range: entity.name,
+        range: entity.range,
       }),
       containerName: 'example',
     } as SymbolInformation;
@@ -326,13 +322,18 @@ export const toDocumentSymbols = (
  * @param error parser error
  * @param uri uri string
  */
-export const parseToDiagnostics = (error: ParseError, diagnostics: DiagnosticUri[] = []): DiagnosticUri[] => {
-  diagnostics.push(createDiagnosticUri(
-    error.token,
-    error.message,
-    DiagnosticSeverity.Error,
-    DIAGNOSTICS.PARSER_ERROR,
-  ));
+export const parseToDiagnostics = (
+  error: ParseError,
+  diagnostics: DiagnosticUri[] = [],
+): DiagnosticUri[] => {
+  diagnostics.push(
+    createDiagnosticUri(
+      error.token,
+      error.message,
+      DiagnosticSeverity.Error,
+      DIAGNOSTICS.PARSER_ERROR,
+    ),
+  );
 
   for (const inner of error.inner) {
     parseToDiagnostics(inner, diagnostics);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This pr now indicates a symbols containing range. This is most relevant for functions and anonymous functions. This range allows editors to produce a hierarchy of symbols where functions can "own" child symbols such as variables declared inside.


* **What is the current behavior?** (You can also link to an open issue here)
The range currently indicates the identifier for the token


* **What is the new behavior (if this is a feature change)?**
The range now indicates the full range of the declaration.

