### PR TITLE
Structure can now be used in all places

### DIFF
--- a/server/src/analysis/models/symbolTableBuilder.ts
+++ b/server/src/analysis/models/symbolTableBuilder.ts
@@ -569,10 +569,7 @@ export class SymbolTableBuilder {
     }
 
     const scopeNode = this.selectScopeNode(scopeKind);
-    const tracker = new BasicTracker(
-      new KsParameter(token, range),
-      this.uri,
-    );
+    const tracker = new BasicTracker(new KsParameter(token, range), this.uri);
 
     token.tracker = tracker;
     scopeNode.environment.set(token.lookup, KsSymbolKind.parameter, tracker);
@@ -624,7 +621,9 @@ export class SymbolTableBuilder {
     ) {
       return createDiagnostic(
         token,
-        `${symbolType} ${token.lexeme} may not exist at script runtime.`,
+        `${toCase(CaseKind.pascalCase, KsSymbolKind[symbolType])} ${
+          token.lexeme
+        } may not exist at script runtime.`,
         DiagnosticSeverity.Hint,
         DIAGNOSTICS.SYMBOL_MAY_NOT_RUNTIME_EXIST,
         [


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #120 by allowing structure to be applied in more places.

* **What is the current behavior?** (You can also link to an open issue here)
Several locations considered structure an error. This is in almost all cases incorrect because it indicates a location the type checking couldn't infer the type. This lead to many false positives.

* **What is the new behavior (if this is a feature change)?**
The following places allow structures now
* calls on a structure
* indexing a structure
* binary operation between two structures

