### PR TITLE
Automatically detect version # from package.json

### DIFF
--- a/clients/vscode/package-lock.json
+++ b/clients/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kos-vscode-client",
-    "version": "0.14.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-vscode",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kos-language-server",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,8 +11,10 @@ import program from 'commander';
 import { typeInitializer } from './typeChecker/initialize';
 import { defaultWorkspaceConfiguration } from './config/models/workspaceConfiguration';
 import { defaultServerConfiguration } from './config/models/serverConfiguration';
+import packageJson from '../package.json';
 
-const version = '0.14.0';
+const defaultVersion = '1.0.0';
+const version = packageJson?.version ?? defaultVersion;
 
 program
   .version(version, '-v --version')

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noEmit": false,
+    "resolveJsonModule": true,
     "incremental": false
     // "tsBuildInfoFile": "./build/buildcache.json",
   },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This will allow the npm deployed version of kos-language-server `kls` to directly read it's version off of `package.json`. Sometimes I would forget to bump the number so it should now forever be in sync with the correct version.
