### PR TITLE
Add call sites as foldable regions

### DIFF
--- a/server/src/services/foldableService.ts
+++ b/server/src/services/foldableService.ts
@@ -1,6 +1,7 @@
 import { empty } from '../utilities/typeGuards';
 import { IStack } from '../analysis/types';
 import * as Stmt from '../parser/models/stmt';
+import * as SuffixTerm from '../parser/models/suffixTerm';
 import { FoldingRange, FoldingRangeKind } from 'vscode-languageserver';
 import { TokenType } from '../models/tokentypes';
 import { TreeTraverse } from '../utilities/treeTraverse';
@@ -48,7 +49,7 @@ export class FoldableService extends TreeTraverse {
   }
 
   /**
-   * Visit block statements to identify when folding regions are present
+   * Visit block statements to add to list of foldable regions
    * @param stmt block statement
    */
   public visitBlock(stmt: Stmt.Block): void {
@@ -62,6 +63,24 @@ export class FoldableService extends TreeTraverse {
 
     for (const childStmt of stmt.stmts) {
       this.stmtAction(childStmt);
+    }
+  }
+
+  /**
+   * Visit call suffix terms to add to list of foldable regions
+   * @param call call site
+   */
+  public visitCall(call: SuffixTerm.Call) {
+    this.result.push({
+      startCharacter: call.open.start.character,
+      startLine: call.open.start.line,
+      endCharacter: call.close.end.character,
+      endLine: call.close.end.line,
+      kind: FoldingRangeKind.Region,
+    });
+
+    for (const arg of call.args) {
+      this.exprAction(arg);
     }
   }
 

--- a/server/test/services/foldableService.spec.ts
+++ b/server/test/services/foldableService.spec.ts
@@ -1,6 +1,4 @@
-import {
-  FoldableService,
-} from '../../src/services/foldableService';
+import { FoldableService } from '../../src/services/foldableService';
 import { FoldingRange } from 'vscode-languageserver';
 import { parseSource, noParseErrors } from '../utilities/setup';
 
@@ -17,117 +15,160 @@ if true {
 }
 
 function example {
-  print("hi").
+  print "hi".
 }
 `;
 
-const bothFold = `
+const callFold = `
+local l is list(
+  "cat",
+  "dog",
+  "ship"
+).
+`;
+
+const allFold = `
 // #region
 if true {
-
+  local l is list(
+    "cat",
+    "dog",
+    "ship"
+  ).
 }
 
 function example {
-  print("hi").
+  print "hi".
 }
 // #endregion
 `;
 // #endregion
 
 describe('foldableService', () => {
-  test('Fold region', () => {
-    debugger;
-    const result = parseSource(regionFold);
-    noParseErrors(result);
-    const { region, endRegion } = result.directives.directives;
+  describe('when a set of regions tags are present', () => {
+    test('identifies a fold region', () => {
+      debugger;
+      const result = parseSource(regionFold);
+      noParseErrors(result);
+      const { region, endRegion } = result.directives.directives;
 
+      const service = new FoldableService();
+      const foldable = service.findRegions(result.parse.script, [
+        ...region,
+        ...endRegion,
+      ]);
 
-    const service = new FoldableService();
-    const foldable = service.findRegions(
-      result.parse.script,
-      [...region, ...endRegion]
-    );
-
-    const folds: FoldingRange[] = [
-      {
+      expect(foldable).toEqual([{
         startCharacter: 0,
         startLine: 1,
         endCharacter: 13,
         endLine: 3,
         kind: 'region',
-      },
-    ];
-
-    expect(foldable).toContainEqual(folds[0]);
+      }]);
+    });
   });
 
-  test('Fold block', () => {
-    const result = parseSource(blockFold);
-    noParseErrors(result);
+  describe('when a call is present', () => {
+    test('identifies the fold region', () => {
+      const result = parseSource(callFold);
+      noParseErrors(result);
 
-    const { region, endRegion } = result.directives.directives;
+      const { region, endRegion } = result.directives.directives;
 
-    const service = new FoldableService();
-    const foldable = service.findRegions(
-      result.parse.script,  
-      [...region, ...endRegion]
-    );
+      const service = new FoldableService();
+      const foldable = service.findRegions(result.parse.script, [
+        ...region,
+        ...endRegion,
+      ]);
 
-    expect(foldable).toHaveLength(2);
-    const folds: FoldingRange[] = [
-      {
-        startCharacter: 8,
+      expect(foldable).toHaveLength(1);
+
+      expect(foldable).toEqual([{
+        startCharacter: 15,
         startLine: 1,
         endCharacter: 1,
-        endLine: 3,
+        endLine: 5,
         kind: 'region',
-      },
-      {
-        startCharacter: 17,
-        startLine: 5,
-        endCharacter: 1,
-        endLine: 7,
-        kind: 'region',
-      },
-    ];
+      }]);
+    });
+  });
 
-    expect(foldable).toContainEqual(folds[0]);
-    expect(foldable).toContainEqual(folds[1]);
+  describe('when a blocks is present', () => {
+    test('identifies the fold regions', () => {
+      const result = parseSource(blockFold);
+      noParseErrors(result);
+
+      const { region, endRegion } = result.directives.directives;
+
+      const service = new FoldableService();
+      const foldable = service.findRegions(result.parse.script, [
+        ...region,
+        ...endRegion,
+      ]);
+
+      expect(foldable).toHaveLength(2);
+      const folds: FoldingRange[] = [
+        {
+          startCharacter: 8,
+          startLine: 1,
+          endCharacter: 1,
+          endLine: 3,
+          kind: 'region',
+        },
+        {
+          startCharacter: 17,
+          startLine: 5,
+          endCharacter: 1,
+          endLine: 7,
+          kind: 'region',
+        },
+      ];
+
+      expect(foldable).toContainEqual(folds[0]);
+      expect(foldable).toContainEqual(folds[1]);
+    });
   });
 
   test('Fold both', () => {
-    const result = parseSource(bothFold);
+    const result = parseSource(allFold);
     noParseErrors(result);
 
     const { region, endRegion } = result.directives.directives;
 
     const service = new FoldableService();
-    const foldable = service.findRegions(
-      result.parse.script,
-      [...region, ...endRegion],
-    );
+    const foldable = service.findRegions(result.parse.script, [
+      ...region,
+      ...endRegion,
+    ]);
 
-    expect(foldable).toHaveLength(3);
+    expect(foldable).toHaveLength(4);
     const folds: FoldingRange[] = [
       {
         startCharacter: 8,
         startLine: 2,
         endCharacter: 1,
-        endLine: 4,
+        endLine: 8,
         kind: 'region',
       },
       {
         startCharacter: 17,
-        startLine: 6,
+        startLine: 3,
+        endCharacter: 3,
+        endLine: 7,
+        kind: 'region',
+      },
+      {
+        startCharacter: 17,
+        startLine: 10,
         endCharacter: 1,
-        endLine: 8,
+        endLine: 12,
         kind: 'region',
       },
       {
         startCharacter: 0,
         startLine: 1,
         endCharacter: 13,
-        endLine: 9,
+        endLine: 13,
         kind: 'region',
       },
     ];
@@ -135,5 +176,6 @@ describe('foldableService', () => {
     expect(foldable).toContainEqual(folds[0]);
     expect(foldable).toContainEqual(folds[1]);
     expect(foldable).toContainEqual(folds[2]);
+    expect(foldable).toContainEqual(folds[3]);
   });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds call sites to the list of foldable regions. Previously only blocks and `#region / #endregion` directives generated foldable regions.

