### PR TITLE
Fix print statement.

### DIFF
--- a/kerboscripts/parser_valid/test_error.ks
+++ b/kerboscripts/parser_valid/test_error.ks
@@ -1,0 +1,6 @@
+local Options is list().
+local i is 0.
+local page is 0.
+
+print (i - (1 * page)) + ") - " + Options[i]. 
+print "" + (i - (1 * page)) + ") - " + Options[i]. 

--- a/lastTime.md
+++ b/lastTime.md
@@ -1,3 +1,0 @@
-General shortterm goals
-
-

--- a/server/src/analysis/resolver.ts
+++ b/server/src/analysis/resolver.ts
@@ -965,6 +965,8 @@ export class Resolver
    * @param stmt the syntax node
    */
   public visitPrint(stmt: Stmt.Print): Diagnostics {
+    this.tableBuilder.setBinding(stmt.print);
+
     const errors = this.useExprLocalsBind(stmt.expr);
     errors.push(...this.resolveExpr(stmt.expr));
 

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -96,7 +96,7 @@ export class Parser {
       }
 
       return {
-        diagnostics: diagnostics,
+        diagnostics,
         script: new Script(this.uri, statements, this.runStmts),
       };
     } catch (err) {
@@ -1316,10 +1316,7 @@ export class Parser {
       errors.push(...args.errors);
     }
 
-    return this.addRunStmts(
-      new Stmt.RunOncePath(builder),
-      errors,
-    );
+    return this.addRunStmts(new Stmt.RunOncePath(builder), errors);
   }
 
   /**
@@ -1390,13 +1387,12 @@ export class Parser {
       close: undefined,
     };
     builder.print = this.previous();
-
-    // if we find function variant of print use that instead
-    if (this.check(TokenType.bracketOpen)) {
-      // Note this back only exists because of identifier led statement quarks
-      this.backup();
-      return this.identifierLedStatement();
-    }
+    // // if we find function variant of print use that instead
+    // if (this.check(TokenType.bracketOpen)) {
+    //   // Note this back only exists because of identifier led statement quarks
+    //   this.backup();
+    //   return this.identifierLedStatement();
+    // }
 
     const expr = this.expression();
     builder.expr = expr.value;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes #144 where the wrong error was reported for a print statement. This was a a result of print statement using special logic if immediately followed by `(expr)`. This was removed and instead the print token is directly assigned the print functions type.

