### PR TITLE
Parameter order correction

### DIFF
--- a/server/src/analysis/standardLibrary.ts
+++ b/server/src/analysis/standardLibrary.ts
@@ -339,7 +339,7 @@ const functionTypes: [string[], IType][] = [
   [['mod'], createFunctionType('mod', scalarType, scalarType, scalarType)],
   [
     ['move', 'path'],
-    createFunctionType('movepath',noneType, stringType, stringType),
+    createFunctionType('movepath', noneType, stringType, stringType),
   ],
   [
     ['node'],

--- a/server/src/analysis/standardLibrary.ts
+++ b/server/src/analysis/standardLibrary.ts
@@ -89,8 +89,8 @@ const functionTypes: [string[], IType][] = [
       'addalarm',
       kacAlarmType,
       stringType,
-      stringType,
       scalarType,
+      stringType,
       stringType,
     ),
   ],
@@ -100,7 +100,7 @@ const functionTypes: [string[], IType][] = [
   ],
   [
     ['angle', 'axis'],
-    createFunctionType('angleaxis', directionType, vectorType, scalarType),
+    createFunctionType('angleaxis', directionType, scalarType, vectorType),
   ],
   [
     ['angle', 'diff'],
@@ -339,12 +339,7 @@ const functionTypes: [string[], IType][] = [
   [['mod'], createFunctionType('mod', scalarType, scalarType, scalarType)],
   [
     ['move', 'path'],
-    createFunctionType(
-      'movepath',
-      noneType,
-      createUnion(true, integerType, noneType),
-      createUnion(true, integerType, noneType),
-    ),
+    createFunctionType('movepath',noneType, stringType, stringType),
   ],
   [
     ['node'],
@@ -362,7 +357,7 @@ const functionTypes: [string[], IType][] = [
     createFunctionType(
       'note',
       noteType,
-      scalarType,
+      createUnion(true, scalarType, stringType),
       scalarType,
       createUnion(true, scalarType, noneType),
       createUnion(true, scalarType, noneType),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR corrects a handful of incorrect function parameters in standardLibrary.ts.

* **What is the current behavior?** (You can also link to an open issue here)
A handful of functions have parameters in the wrong order, or just the wrong parameters.

* **Other information**:
Discovered while looking at a piece of code I knew was correct that was displaying 'type-wrong' errors on parameters for ANGLEAXIS(), figured I might as well scan through the rest of them as well and found a couple others.