### PR TITLE
Update initialize.ts

### DIFF
--- a/server/src/typeChecker/ksTypes/parts/initialize.ts
+++ b/server/src/typeChecker/ksTypes/parts/initialize.ts
@@ -53,7 +53,7 @@ export const partInitializer = () => {
     noMap(createSuffixType('ship', vesselTargetType)),
     noMap(createArgSuffixType('hasModule', booleanType, stringType)),
     noMap(createArgSuffixType('getModule', partModuleType, stringType)),
-    noMap(createArgSuffixType('getModulesByIndex', partModuleType, scalarType)),
+    noMap(createArgSuffixType('getModuleByIndex', partModuleType, scalarType)),
     noMap(createSuffixType('modules', listType.apply(stringType))),
     noMap(createSuffixType('allModules', listType.apply(stringType))),
     noMap(createSuffixType('parent', createUnion(false, partType, stringType))),


### PR DESCRIPTION
There was a typo in GetModuleByIndex (it had an 's' making it GetModulesByIndex).  See here for KOS documentation:  https://ksp-kos.github.io/KOS/structures/vessels/part.html#PART:GETMODULEBYINDEX
